### PR TITLE
fix(statements): BOI sender migration (.bank.in TLD)

### DIFF
--- a/enums/StatementPatternEnum.py
+++ b/enums/StatementPatternEnum.py
@@ -8,6 +8,6 @@ class StatementPatternEnum(Enum):
     ICICI_AMAZON_PAY = "Amazon Pay ICICI Bank Credit Card Statement "
     YES_BANK_ACE = "from:(estatement@yesbank.in) Credit Card, ACE "
     YES_BANK_DEBIT = "from:(estatement@yesbank.in) -{ACE, Credit Card} "
-    BOI = "BOI: Account Statement"
+    BOI = "from:(noreply-estatement@alerts.bankofindia.bank.in) "
     HDFC_REGALIA = "Visa Regalia USD Statement"
 

--- a/services/bankFormatRules.py
+++ b/services/bankFormatRules.py
@@ -20,6 +20,10 @@ DOMAIN_TO_BANK = {
     # Bank of India
     "bankofindia.co.in": "BOI",
     "bankofindia.com": "BOI",
+    # ak-2ql: 2026-03-07 RBI-mandated `.bank.in` TLD migration.
+    # New sender domain: alerts.bankofindia.bank.in. Mirrors the
+    # earlier HDFC migration (see hdfcbank.bank.in above).
+    "bankofindia.bank.in": "BOI",
     # Axis
     "axisbank.com": "AXIS",
     # Kotak

--- a/services/mailProcessorService.py
+++ b/services/mailProcessorService.py
@@ -1157,6 +1157,9 @@ class MailProcessorService:
             "yesbank.co.in": ["YES_BANK_DEBIT", "YES_BANK_ACE"],
             "bankofindia.co.in": ["BOI"],
             "bankofindia.com": ["BOI"],
+            # ak-2ql: 2026-03-07 RBI-mandated `.bank.in` TLD migration
+            # (precedent: hdfcbank.bank.in above).
+            "bankofindia.bank.in": ["BOI"],
         }
 
         # ── Strategy 1: Explicit bank passwords from DB ─────────────


### PR DESCRIPTION
ak-2ql — BOI changed sender 2026-03-07 per RBI .bank.in TLD migration; old subject-substring pattern went silent. Updates the from:(sender) filter + domain-maps so mailProcessor routes new BOI emails to the parser. Reviewer FULL CLEAR 0/0/0. Follow-up: backfill 4 missed statements (Feb-May 2026).