### PR TITLE
feat(agent-chat): server-side conversation persistence (ak-bq5)

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,7 @@ from controllers.paymentEP import PaymentController
 from controllers.customFieldEP import CustomFieldController
 from controllers.jobsEP import JobsController
 from controllers.agentEP import AgentController
+from controllers.agentConversationsEP import AgentConversationsController  # ak-bq5
 from controllers.customerEmailEP import CustomerEmailController
 from controllers.fileStorageEP import FileStorageController
 from controllers.jobEmailEP import JobEmailController
@@ -42,6 +43,7 @@ from services.customerEmailService import CustomerEmailService
 from services.fileStorageService import FileStorageService
 from services.jobEmailService import JobEmailService
 from services.agentService import AgentService
+from services.agentConversationService import AgentConversationService  # ak-bq5
 from services.cronAgent import CronAgent
 from services.portfolioVisitorService import PortfolioVisitorService
 from services.mailProcessorService import MailProcessorService
@@ -198,6 +200,10 @@ class Akkountant(Flask):
             mail_processor=self.mailProcessor,
             reconciliation_service=self.reconciliationService,
         )
+        # ak-bq5: cross-device chat persistence — instantiate the
+        # conversation service BEFORE wiring it into AgentService so
+        # set_services receives a ready instance.
+        self.agentConversationService = AgentConversationService()
         self.agentService = AgentService()
         self.agentService.set_services(
             investment_service=self.investmentService,
@@ -206,8 +212,12 @@ class Akkountant(Flask):
             customer_service=self.customerService,
             dashboard_service=self.dashboardService,
             mail_processor=self.mailProcessor,
+            conversation_service=self.agentConversationService,  # ak-bq5
         )
         self.agentEP = AgentController(self.agentService)
+        self.agentConversationsEP = AgentConversationsController(  # ak-bq5
+            self.agentConversationService,
+        )
         self.portfolioVisitorService = PortfolioVisitorService()
         self.portfolioVisitorEP = PortfolioVisitorController(self.portfolioVisitorService)
 
@@ -451,10 +461,22 @@ class Akkountant(Flask):
             ('/portfolio/stats', 'GET', self.portfolioVisitorEP.get_stats),
         ]
 
-        # Agent chat endpoint + ak-1x4 attachment upload
+        # Agent chat endpoint + ak-1x4 attachment upload + ak-bq5
+        # cross-device conversation persistence
         agentRoutes = [
             ('/agent/chat', 'POST', self.agentEP.chat),
             ('/agent/attach', 'POST', self.agentEP.attach),
+            # ak-bq5: cross-device chat persistence endpoints. All
+            # endpoints filter by g.firebase_id (set by before_request
+            # middleware). Soft delete via /agent/conversations/<id>.
+            ('/agent/conversations', 'GET',
+                self.agentConversationsEP.list),
+            ('/agent/conversations', 'POST',
+                self.agentConversationsEP.create),
+            ('/agent/conversations/<conversation_id>', 'GET',
+                self.agentConversationsEP.get),
+            ('/agent/conversations/<conversation_id>', 'DELETE',
+                self.agentConversationsEP.delete),
         ]
 
         # Register all routes

--- a/controllers/agentConversationsEP.py
+++ b/controllers/agentConversationsEP.py
@@ -1,0 +1,148 @@
+"""ak-bq5: REST endpoints for cross-device agent chat persistence.
+
+Routes registered in app.py:
+  GET    /agent/conversations?agent_type=X      → list
+  GET    /agent/conversations/<id>              → full thread
+  POST   /agent/conversations                   → explicit create
+  DELETE /agent/conversations/<id>              → soft delete
+
+All endpoints filter by g.firebase_id (set by the before_request
+middleware). Non-owner / non-existent / soft-deleted → 404 with a
+generic "not found" message — never leak existence via a 403.
+"""
+
+from flask import g, jsonify, request
+
+from services.agentConversationService import (
+    AgentConversationService,
+    VALID_AGENT_TYPES,
+)
+from utils.logger import Logger
+
+
+class AgentConversationsController:
+    def __init__(self, service: AgentConversationService):
+        self.service = service
+        self.logger = Logger(__name__).get_logger()
+
+    @Logger.standardLogger
+    def list(self):
+        """
+        GET /agent/conversations
+        Optional query: agent_type=investment|transaction|freelance
+        Returns: {conversations: [{id, agent_type, title, created_at,
+                                   updated_at, msg_count}, ...]}
+        """
+        user_id = g.get("firebase_id")
+        if not user_id:
+            return jsonify({"error": "Unauthorized"}), 401
+
+        agent_type = request.args.get("agent_type") or None
+        if agent_type and agent_type not in VALID_AGENT_TYPES:
+            return jsonify({
+                "error": (
+                    f"Invalid agent_type {agent_type!r}; "
+                    f"expected one of {list(VALID_AGENT_TYPES)}"
+                )
+            }), 400
+
+        try:
+            convs = self.service.list_conversations(user_id, agent_type=agent_type)
+        except Exception:
+            self.logger.exception("agent_conversations: list failed")
+            return jsonify({"error": "Internal server error"}), 500
+        return jsonify({"conversations": convs}), 200
+
+    @Logger.standardLogger
+    def get(self, conversation_id):
+        """
+        GET /agent/conversations/<conversation_id>
+        Returns: {id, agent_type, title, created_at, updated_at,
+                  msg_count, messages: [{id, role, content,
+                  attachments_meta, partial, ts}, ...]}
+        404 if not owned by current user (cross-user lookup looks
+        identical to a true miss — no existence leak).
+        """
+        user_id = g.get("firebase_id")
+        if not user_id:
+            return jsonify({"error": "Unauthorized"}), 401
+
+        try:
+            payload = self.service.get_conversation(user_id, conversation_id)
+        except Exception:
+            self.logger.exception(
+                "agent_conversations: get failed for id=%s", conversation_id
+            )
+            return jsonify({"error": "Internal server error"}), 500
+
+        if payload is None:
+            return jsonify({"error": "Conversation not found"}), 404
+        return jsonify(payload), 200
+
+    @Logger.standardLogger
+    def create(self):
+        """
+        POST /agent/conversations
+        Body: {agent_type, title?}
+        Returns: {id, agent_type, title, created_at, updated_at, msg_count: 0}
+
+        Optional endpoint per dispatch — the FE typically lets
+        /agent/chat auto-create on first message. Exposed here for
+        explicit "new conversation" UI affordances.
+        """
+        user_id = g.get("firebase_id")
+        if not user_id:
+            return jsonify({"error": "Unauthorized"}), 401
+
+        data = request.get_json(force=True, silent=True) or {}
+        agent_type = data.get("agent_type")
+        if not agent_type:
+            return jsonify({"error": "agent_type is required"}), 400
+        if agent_type not in VALID_AGENT_TYPES:
+            return jsonify({
+                "error": (
+                    f"Invalid agent_type {agent_type!r}; "
+                    f"expected one of {list(VALID_AGENT_TYPES)}"
+                )
+            }), 400
+
+        try:
+            cid = self.service.create_conversation(
+                user_id, agent_type, title=data.get("title"),
+            )
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+        except Exception:
+            self.logger.exception("agent_conversations: create failed")
+            return jsonify({"error": "Internal server error"}), 500
+
+        # Round-trip to surface the auto-set timestamps + canonicalized
+        # title to the caller.
+        payload = self.service.get_conversation(user_id, cid)
+        return jsonify(payload), 201
+
+    @Logger.standardLogger
+    def delete(self, conversation_id):
+        """
+        DELETE /agent/conversations/<conversation_id>
+        Soft delete (deleted_at = now). 404 if not owned by current
+        user. Idempotent on a second call to a deleted conversation
+        (returns 404 the second time — that's correct, the row is
+        no longer in the live set).
+        """
+        user_id = g.get("firebase_id")
+        if not user_id:
+            return jsonify({"error": "Unauthorized"}), 401
+
+        try:
+            ok = self.service.soft_delete(user_id, conversation_id)
+        except Exception:
+            self.logger.exception(
+                "agent_conversations: soft_delete failed for id=%s",
+                conversation_id,
+            )
+            return jsonify({"error": "Internal server error"}), 500
+
+        if not ok:
+            return jsonify({"error": "Conversation not found"}), 404
+        return jsonify({"message": "Conversation deleted"}), 200

--- a/controllers/agentEP.py
+++ b/controllers/agentEP.py
@@ -22,17 +22,26 @@ class AgentController:
         """
         POST /agent/chat
         Body: {agent_type: str, messages: list, confirmed_tools?: list,
-               attachments?: list[str]}
+               attachments?: list[str], conversation_id?: int}
         Returns: SSE stream
 
         attachments (ak-1x4): list of attachment_ids previously returned
         by POST /agent/attach. Investment agent only.
+
+        conversation_id (ak-bq5): optional int — when present, the user
+        message is appended to the existing thread + the assistant
+        reply is appended after the stream completes. When absent, the
+        service layer creates a new conversation row, derives a title
+        from the first user message, and emits a leading SSE event
+        `{"type":"conversation_id","id": ...}` so the FE can pin the
+        id for follow-up turns.
         """
         data = request.get_json(force=True)
         agent_type = data.get("agent_type")
         messages = data.get("messages", [])
         confirmed_tools = data.get("confirmed_tools", [])
         attachments = data.get("attachments", []) or []
+        conversation_id = data.get("conversation_id")  # ak-bq5
         user_id = g.get("firebase_id")
 
         if not agent_type:
@@ -55,6 +64,17 @@ class AgentController:
                 )
             }), 400
 
+        # ak-bq5: optional conversation_id sanity — must be int-coercible.
+        # Membership scope is validated inside the service layer (404 on
+        # miss / cross-user / soft-deleted; surfaced as an SSE error).
+        if conversation_id is not None:
+            try:
+                conversation_id = int(conversation_id)
+            except (TypeError, ValueError):
+                return jsonify({
+                    "error": "conversation_id must be an integer"
+                }), 400
+
         def generate():
             for event in self.agent_service.stream_chat(
                 agent_type=agent_type,
@@ -62,6 +82,7 @@ class AgentController:
                 user_id=user_id,
                 confirmed_tools=confirmed_tools,
                 attachments=attachments,
+                conversation_id=conversation_id,
             ):
                 yield event
 

--- a/models/AgentConversation.py
+++ b/models/AgentConversation.py
@@ -1,0 +1,105 @@
+"""ak-bq5: agent_conversations — cross-device chat persistence header table.
+
+One row per conversation thread the user has had with one of the
+three domain agents (investment, transaction, freelance).
+
+Lifecycle:
+  - Created on the first POST /agent/chat that comes in without a
+    conversation_id, OR via explicit POST /agent/conversations.
+  - title is derived from the first 60 chars of the first user message
+    (newlines stripped, whitespace collapsed) at creation time. No LLM
+    call.
+  - updated_at bumped on every message append.
+  - Soft delete via deleted_at; the list endpoint filters this out.
+
+Scope guards (per dispatch hq-wisp-rr15b):
+  - All endpoints filter by user_id == g.firebase_id — cross-user
+    isolation is non-negotiable.
+  - Title rename, LLM titling, attachment durability all OUT of scope
+    here; flag follow-up beads if desired.
+"""
+
+from sqlalchemy import (
+    Column, String, Integer, DateTime, ForeignKey, Index, func,
+)
+from sqlalchemy.orm import relationship
+
+from models.Base import Base
+
+
+class AgentConversation(Base):
+    """Header row for a single agent chat thread.
+
+    The (user_id, agent_type, updated_at DESC) compound index makes
+    the list query — "what conversations does user X have for the
+    investment agent, most recent first" — an index-only scan.
+    """
+
+    __tablename__ = 'agent_conversations'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    # firebase_id (alphanumeric); CASCADE so when a user is removed
+    # in dev/test their conversations follow.
+    user_id = Column(
+        String(100),
+        ForeignKey('users.userID', ondelete='CASCADE'),
+        nullable=False,
+    )
+    # Matches the agent_type validation in controllers/agentEP.py.
+    # Stored as a free string (not Enum) so adding a 4th agent later
+    # doesn't require a schema migration.
+    agent_type = Column(String(40), nullable=False)
+    # 60-char cap is enforced at write time (see
+    # agentConversationService.derive_title); 120 here gives headroom
+    # for an LLM-generated title in a later iteration without re-migrate.
+    title = Column(String(120), nullable=False, default="New conversation")
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+    # updated_at bumped on every append_message; the list view orders by this
+    # so the most-recently-active thread surfaces first.
+    updated_at = Column(
+        DateTime, nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+    # Soft delete (per scope doc decision 4). NULL == live. List query
+    # filters this. Hard delete reserved for a future cleanup job.
+    deleted_at = Column(DateTime, nullable=True)
+
+    messages = relationship(
+        'AgentMessage',
+        back_populates='conversation',
+        cascade='all, delete-orphan',
+        order_by='AgentMessage.id',
+    )
+
+    __table_args__ = (
+        # Hot path: list query orders by (user_id, agent_type, updated_at DESC).
+        # `updated_at` is the leftmost-DESC column so the index serves
+        # the ORDER BY directly. Single composite index covers the
+        # common filter + sort.
+        Index(
+            'ix_agent_conv_user_type_updated',
+            'user_id', 'agent_type', 'updated_at',
+        ),
+        # Quick lookup by id within a user — used by the GET-single
+        # and DELETE-single endpoints which scope to user_id.
+        Index('ix_agent_conv_user', 'user_id'),
+    )
+
+    def to_summary_dict(self, message_count=None):
+        """Shape returned by GET /agent/conversations?agent_type=X.
+
+        message_count is computed by the service layer (saves a
+        round-trip per row when batched in the caller). Pass None to
+        omit it (e.g. for the single-conversation GET).
+        """
+        out = {
+            "id": self.id,
+            "agent_type": self.agent_type,
+            "title": self.title,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+        if message_count is not None:
+            out["msg_count"] = message_count
+        return out

--- a/models/AgentMessage.py
+++ b/models/AgentMessage.py
@@ -8,13 +8,16 @@ content stores the message text verbatim. For the assistant role this
 is the concatenation of TextBlocks the SDK returned (matching what
 agentService.stream_chat yields as the "text" event payload).
 
-attachments_meta stores DESCRIPTORS only — NOT the bytes. See dispatch
-hq-wisp-rr15b:
-  > Persisted messages keep attachment metadata (filename, type, size,
-  > sha256) but NOT the bytes. Existing /tmp/akkountant-agent-attachments/...
-  > sweep behavior unchanged.
-The FE renders "[attachment expired]" when the referenced uuid is no
-longer on disk.
+attachments_meta stores DESCRIPTORS only — NOT the bytes. Shape per
+descriptor: {attachment_id, filename, content_type, size}. Built from
+the resolved attachment records in agentService.stream_chat AFTER
+the per-user attachment subtree is validated, then persisted with
+the user message. The FE renders "[attachment expired]" when the
+referenced uuid is no longer on disk (sweep ran post-turn).
+
+Note: sha256 was mentioned in the dispatch but is NOT currently
+computed. Adding it is a follow-up (cheap — open the bytes once at
+resolve time, hash, add to the dict).
 
 partial flag: set TRUE if the SSE stream was interrupted mid-assistant-
 turn (e.g. FE disconnect, SDK error after some text). The FE can show a
@@ -52,10 +55,12 @@ class AgentMessage(Base):
     # write time by agentConversationService.append_message.
     role = Column(String(20), nullable=False)
     content = Column(Text, nullable=False)
-    # JSON column: a list of {filename, mime, size, sha256, attachment_id}
+    # JSON column: a list of {attachment_id, filename, content_type, size}
     # descriptors when the user attached files this turn. NULL when no
     # attachments. We do NOT store the on-disk path or the bytes —
     # ephemeral sweep semantics from ak-1x4 apply.
+    # (sha256 was in the original dispatch but isn't computed today —
+    # tracked as a follow-up; cheap to add at resolve time.)
     attachments_meta = Column(JSON, nullable=True)
     # See class docstring on `partial`. Default FALSE.
     partial = Column(Boolean, nullable=False, default=False, server_default='0')

--- a/models/AgentMessage.py
+++ b/models/AgentMessage.py
@@ -1,0 +1,81 @@
+"""ak-bq5: agent_messages — one row per chat turn (user / assistant / tool).
+
+Ordering: rows are ordered by id (autoincrement) within a conversation.
+We don't rely on `ts` for ordering because two rows could share an
+identical millisecond timestamp; id is monotonic per row insert.
+
+content stores the message text verbatim. For the assistant role this
+is the concatenation of TextBlocks the SDK returned (matching what
+agentService.stream_chat yields as the "text" event payload).
+
+attachments_meta stores DESCRIPTORS only — NOT the bytes. See dispatch
+hq-wisp-rr15b:
+  > Persisted messages keep attachment metadata (filename, type, size,
+  > sha256) but NOT the bytes. Existing /tmp/akkountant-agent-attachments/...
+  > sweep behavior unchanged.
+The FE renders "[attachment expired]" when the referenced uuid is no
+longer on disk.
+
+partial flag: set TRUE if the SSE stream was interrupted mid-assistant-
+turn (e.g. FE disconnect, SDK error after some text). The FE can show a
+"stream interrupted" badge so the user knows the assistant message is
+incomplete.
+"""
+
+from sqlalchemy import (
+    Column, String, Integer, DateTime, ForeignKey, Boolean, Text,
+    JSON, Index, func,
+)
+from sqlalchemy.orm import relationship
+
+from models.Base import Base
+
+
+# Roles match the Anthropic message-shape vocabulary. 'tool' isn't
+# emitted by the current pipeline (we shape MCP tool results back into
+# assistant turns), but the column accepts it so future tool-event
+# persistence doesn't require a schema migration.
+AGENT_MESSAGE_ROLES = ('user', 'assistant', 'tool')
+
+
+class AgentMessage(Base):
+    __tablename__ = 'agent_messages'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    conversation_id = Column(
+        Integer,
+        ForeignKey('agent_conversations.id', ondelete='CASCADE'),
+        nullable=False,
+    )
+    # Stored as a free string (not Enum) for the same forward-compat
+    # reason as agent_type on the conversation header. Validated at
+    # write time by agentConversationService.append_message.
+    role = Column(String(20), nullable=False)
+    content = Column(Text, nullable=False)
+    # JSON column: a list of {filename, mime, size, sha256, attachment_id}
+    # descriptors when the user attached files this turn. NULL when no
+    # attachments. We do NOT store the on-disk path or the bytes —
+    # ephemeral sweep semantics from ak-1x4 apply.
+    attachments_meta = Column(JSON, nullable=True)
+    # See class docstring on `partial`. Default FALSE.
+    partial = Column(Boolean, nullable=False, default=False, server_default='0')
+    ts = Column(DateTime, nullable=False, server_default=func.now())
+
+    conversation = relationship('AgentConversation', back_populates='messages')
+
+    __table_args__ = (
+        # GET /agent/conversations/<id> loads all messages for a given
+        # conversation ordered by id. Indexed for that.
+        Index('ix_agent_msg_conv_id', 'conversation_id', 'id'),
+    )
+
+    def to_dict(self):
+        """Shape returned alongside GET /agent/conversations/<id>."""
+        return {
+            "id": self.id,
+            "role": self.role,
+            "content": self.content,
+            "attachments_meta": self.attachments_meta,  # already JSON-typed
+            "partial": bool(self.partial),
+            "ts": self.ts.isoformat() if self.ts else None,
+        }

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -25,3 +25,9 @@ from .user_files import UserFolder, UserFile
 from .jobEmails import JobEmail
 from .jobProcessedEmails import ProcessedEmail as JobProcessedEmail
 from .portfolioVisitors import PortfolioVisitor
+# ak-bq5: cross-device agent chat persistence — see dispatch hq-wisp-rr15b.
+# Order: AgentConversation first so AgentMessage's FK target exists at
+# create_all() time. Both must be imported BEFORE db.create_all() runs
+# in app.py so the schema is materialized.
+from .AgentConversation import AgentConversation
+from .AgentMessage import AgentMessage, AGENT_MESSAGE_ROLES

--- a/services/agentConversationService.py
+++ b/services/agentConversationService.py
@@ -1,0 +1,227 @@
+"""ak-bq5: cross-device agent chat persistence — service layer.
+
+Encapsulates all reads / writes to agent_conversations + agent_messages
+so the controllers stay shaped like the existing REST endpoints (thin
+JSON shim) and stream_chat in agentService stays focused on the SDK
+loop.
+
+Scope guards (per dispatch hq-wisp-rr15b):
+  - Every read AND write filters by user_id == g.firebase_id. The
+    controller passes user_id through; service refuses to operate on
+    a conversation it can't prove belongs to the caller. Returns None
+    on mismatch so the controller maps to 404 (no leak via
+    "permission denied" vs "not found").
+  - Soft delete: deleted_at IS NULL filter on every list / get query.
+  - Title derived at create time from first 60 chars of the first
+    user message (newlines stripped, whitespace collapsed) — no LLM
+    call.
+"""
+
+import re
+from datetime import datetime
+
+from sqlalchemy import func
+
+from models import AgentConversation, AgentMessage, AGENT_MESSAGE_ROLES
+from services.Base_Service import BaseService
+from utils.logger import Logger
+
+
+# Title length cap is the column width minus headroom for later edit;
+# matches the dispatch's "60 chars of first user msg" decision.
+TITLE_MAX_LEN = 60
+DEFAULT_TITLE = "New conversation"
+
+# Matches what controllers/agentEP.py accepts.
+VALID_AGENT_TYPES = ('investment', 'transaction', 'freelance')
+
+# Whitespace-collapse regex used by derive_title.
+_WS_RE = re.compile(r"\s+")
+
+
+def derive_title(first_user_message_content):
+    """Build a conversation title from the first user message.
+
+    Strips newlines + collapses runs of whitespace to a single space,
+    then truncates to TITLE_MAX_LEN. Falls back to DEFAULT_TITLE for
+    empty / whitespace-only input so the column never carries an empty
+    string (the FE renders title prominently in the conversation list).
+    """
+    if not first_user_message_content or not isinstance(first_user_message_content, str):
+        return DEFAULT_TITLE
+    cleaned = _WS_RE.sub(" ", first_user_message_content).strip()
+    if not cleaned:
+        return DEFAULT_TITLE
+    if len(cleaned) <= TITLE_MAX_LEN:
+        return cleaned
+    # Truncate at a word boundary if there's a space within the last
+    # ~10 chars — produces nicer titles. Falls back to a hard cut.
+    cut = cleaned[:TITLE_MAX_LEN]
+    last_space = cut.rfind(" ")
+    if last_space >= TITLE_MAX_LEN - 10:
+        cut = cut[:last_space]
+    return cut + "…"
+
+
+class AgentConversationService(BaseService):
+    """Singleton service following the same pattern as AgentService.
+
+    Methods take a user_id explicitly rather than reading from g so the
+    same code is callable from the SSE generator inside
+    agentService.stream_chat (which already has user_id in scope).
+    """
+
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls.logger = Logger(__name__).get_logger()
+        return cls._instance
+
+    # ── reads ──────────────────────────────────────────────────────────
+
+    def list_conversations(self, user_id, agent_type=None):
+        """Return non-soft-deleted conversations for the user, optionally
+        filtered by agent_type. Ordered by updated_at DESC so most-recent
+        threads surface first."""
+        if not user_id:
+            return []
+        q = (
+            self.db.session.query(
+                AgentConversation,
+                func.count(AgentMessage.id).label("msg_count"),
+            )
+            .outerjoin(AgentMessage, AgentMessage.conversation_id == AgentConversation.id)
+            .filter(AgentConversation.user_id == user_id)
+            .filter(AgentConversation.deleted_at.is_(None))
+        )
+        if agent_type:
+            if agent_type not in VALID_AGENT_TYPES:
+                return []
+            q = q.filter(AgentConversation.agent_type == agent_type)
+        q = q.group_by(AgentConversation.id).order_by(
+            AgentConversation.updated_at.desc()
+        )
+        rows = q.all()
+        return [
+            row[0].to_summary_dict(message_count=int(row[1] or 0))
+            for row in rows
+        ]
+
+    def get_conversation(self, user_id, conversation_id):
+        """Fetch one conversation + its messages, owned by user_id.
+        Returns None if not found, soft-deleted, or owned by a
+        different user — controller maps None to 404."""
+        if not user_id or not conversation_id:
+            return None
+        conv = self._fetch_owned(user_id, conversation_id)
+        if conv is None:
+            return None
+        # AgentConversation.messages relationship is order_by id already,
+        # but reach via the session-scoped query so SQLAlchemy doesn't
+        # cache stale state across requests.
+        messages = (
+            self.db.session.query(AgentMessage)
+            .filter(AgentMessage.conversation_id == conv.id)
+            .order_by(AgentMessage.id.asc())
+            .all()
+        )
+        out = conv.to_summary_dict(message_count=len(messages))
+        out["messages"] = [m.to_dict() for m in messages]
+        return out
+
+    # ── writes ─────────────────────────────────────────────────────────
+
+    def create_conversation(self, user_id, agent_type, title=None,
+                            first_user_message=None):
+        """Insert a new conversation row. If title is None, derive from
+        first_user_message; if both are None, falls back to
+        DEFAULT_TITLE.
+
+        Returns the integer id of the new row (NOT the model object —
+        the caller often only needs the id for the SSE preamble).
+        """
+        if not user_id:
+            raise ValueError("create_conversation: user_id required")
+        if agent_type not in VALID_AGENT_TYPES:
+            raise ValueError(
+                f"create_conversation: invalid agent_type {agent_type!r}; "
+                f"expected one of {VALID_AGENT_TYPES}"
+            )
+        if title is None:
+            title = derive_title(first_user_message)
+        conv = AgentConversation(
+            user_id=user_id,
+            agent_type=agent_type,
+            title=title,
+        )
+        self.db.session.add(conv)
+        self.db.session.commit()
+        return conv.id
+
+    def append_message(self, user_id, conversation_id, role, content,
+                       attachments_meta=None, partial=False):
+        """Insert one message row. Bumps the conversation's updated_at
+        so list ordering reflects activity.
+
+        Validates the role against AGENT_MESSAGE_ROLES and confirms the
+        conversation belongs to user_id before writing. Returns the
+        new message id, or None if the conversation doesn't belong to
+        the user / doesn't exist.
+        """
+        if role not in AGENT_MESSAGE_ROLES:
+            raise ValueError(
+                f"append_message: invalid role {role!r}; "
+                f"expected one of {AGENT_MESSAGE_ROLES}"
+            )
+        if content is None:
+            content = ""
+        conv = self._fetch_owned(user_id, conversation_id)
+        if conv is None:
+            return None
+        msg = AgentMessage(
+            conversation_id=conv.id,
+            role=role,
+            content=str(content),
+            attachments_meta=attachments_meta,
+            partial=bool(partial),
+        )
+        self.db.session.add(msg)
+        # Explicit updated_at bump so the ORDER BY in list_conversations
+        # reflects the new activity even if the DB's onupdate trigger
+        # doesn't fire on this dialect.
+        conv.updated_at = datetime.utcnow()
+        self.db.session.commit()
+        return msg.id
+
+    def soft_delete(self, user_id, conversation_id):
+        """Set deleted_at on a user's conversation. Returns True on
+        success, False if not owned / not found / already deleted."""
+        conv = self._fetch_owned(user_id, conversation_id)
+        if conv is None:
+            return False
+        conv.deleted_at = datetime.utcnow()
+        self.db.session.commit()
+        return True
+
+    # ── helpers ────────────────────────────────────────────────────────
+
+    def _fetch_owned(self, user_id, conversation_id):
+        """Return a live (non-soft-deleted) AgentConversation owned by
+        user_id, else None. Single source of truth for the membership
+        check — every read/write helper goes through here so a future
+        permissions change has exactly one site to update."""
+        if not user_id or not conversation_id:
+            return None
+        try:
+            cid = int(conversation_id)
+        except (TypeError, ValueError):
+            return None
+        return (
+            self.db.session.query(AgentConversation)
+            .filter(AgentConversation.id == cid)
+            .filter(AgentConversation.user_id == user_id)
+            .filter(AgentConversation.deleted_at.is_(None))
+            .first()
+        )

--- a/services/agentService.py
+++ b/services/agentService.py
@@ -328,10 +328,17 @@ class AgentService(BaseService):
         self.customer_service = None
         self.dashboard_service = None
         self.mail_processor = None
+        # ak-bq5: injected by app.py during route setup. None means
+        # persistence is OFF (stateless legacy behavior) — code paths
+        # guard on `self.conversation_service is not None` so the SDK
+        # loop runs cleanly even without it (useful in offline tests
+        # that mock the heavy app boot).
+        self.conversation_service = None
 
     def set_services(self, investment_service=None, transaction_service=None,
                      invoice_service=None, customer_service=None,
-                     dashboard_service=None, mail_processor=None):
+                     dashboard_service=None, mail_processor=None,
+                     conversation_service=None):
         """Called from app.py to inject existing service instances."""
         self.investment_service = investment_service
         self.transaction_service = transaction_service
@@ -339,14 +346,18 @@ class AgentService(BaseService):
         self.customer_service = customer_service
         self.dashboard_service = dashboard_service
         self.mail_processor = mail_processor
+        # ak-bq5: optional — only wired when chat persistence is active.
+        if conversation_service is not None:
+            self.conversation_service = conversation_service
 
     def stream_chat(self, agent_type, messages, user_id, confirmed_tools=None,
-                    attachments=None):
+                    attachments=None, conversation_id=None):
         """
         Generator that yields SSE events for the agent chat.
         Uses claude_agent_sdk with MCP tools to process queries.
 
         Event types:
+        - conversation_id: {"type": "conversation_id", "id": int}  (ak-bq5)
         - text: {"type": "text", "content": "..."}
         - tool_exec: {"type": "tool_exec", "tool": "..."}
         - confirm: {"type": "confirm", "tool": "...", "input": {...}, "message": "..."}
@@ -361,16 +372,121 @@ class AgentService(BaseService):
         deleted in the finally block — ephemeral per-turn lifecycle.
         Resolution failures (deleted, cross-user, malformed id) emit a
         single SSE error event and bail before the SDK runs.
+
+        conversation_id (ak-bq5): optional int. When None AND a
+        conversation_service is wired, a new conversation row is created
+        from the last user message (title derived from first 60 chars)
+        and the assigned id is emitted as the leading SSE event. When
+        present, the user message is appended to that thread. When the
+        id is provided but doesn't belong to the caller (or is
+        soft-deleted), an SSE error event is yielded and the stream
+        bails BEFORE the SDK runs — saves a costly model call on a
+        scope-violating request.
         """
         confirmed_tools = confirmed_tools or []
         attachments = attachments or []
         tool_events = []  # Collected intermediate events (tool_exec, confirm)
         mutations = []
+        # ak-bq5: track the active conversation_id + collected assistant
+        # text so the finally block can persist whatever made it out
+        # (full or partial) without depending on the happy-path tail.
+        active_conversation_id = conversation_id
+        persisted_assistant = False  # set True after a successful save
         # Track resolved attachment_ids so the finally block can clean
         # them up regardless of which exit path the SDK takes.
         attachment_ids_to_cleanup = []
 
         try:
+            # ak-bq5: conversation_id pre-flight + persist user msg
+            # BEFORE any expensive SDK work. Three cases:
+            #
+            # (a) no conversation_service wired → persistence OFF,
+            #     legacy stateless behavior. Skip the whole block.
+            # (b) caller passed a conversation_id → confirm it belongs
+            #     to user_id (soft-deleted / cross-user → SSE error +
+            #     bail without spinning up Claude).
+            # (c) caller passed nothing → create a fresh conversation
+            #     row, derive the title from the last user message,
+            #     emit the new id as the leading SSE event so the FE
+            #     can pin it.
+            #
+            # Then in all "on" cases we append the inbound user message
+            # so the read-back endpoint reflects the full thread even
+            # if the SDK crashes mid-stream.
+            if self.conversation_service is not None:
+                last_user_text = self._extract_last_user_content(messages)
+                if active_conversation_id is None:
+                    try:
+                        active_conversation_id = (
+                            self.conversation_service.create_conversation(
+                                user_id=user_id,
+                                agent_type=agent_type,
+                                first_user_message=last_user_text,
+                            )
+                        )
+                    except ValueError as exc:
+                        yield self._sse_event("error", {"message": str(exc)})
+                        return
+                    except Exception as exc:
+                        # DB write failure is a hard error — don't run
+                        # the SDK if we can't track the turn.
+                        self.logger.exception(
+                            "conversation create failed for user=%s "
+                            "agent_type=%s", user_id, agent_type,
+                        )
+                        yield self._sse_event("error", {
+                            "message": (
+                                "Could not start a new conversation. "
+                                "Please retry."
+                            )
+                        })
+                        return
+                else:
+                    # Existing id — verify ownership before doing
+                    # anything else. get_conversation returns None on
+                    # miss / soft-delete / cross-user (no leak).
+                    owned = self.conversation_service.get_conversation(
+                        user_id, active_conversation_id,
+                    )
+                    if owned is None:
+                        yield self._sse_event("error", {
+                            "message": (
+                                "Conversation not found. It may have "
+                                "been deleted; please start a new chat."
+                            )
+                        })
+                        return
+
+                # Emit the id as the leading SSE event so the FE can
+                # pin it for follow-up turns + persist the user message.
+                yield self._sse_event("conversation_id", {
+                    "id": active_conversation_id,
+                })
+                # Build attachments_meta from the just-parsed attachment
+                # arg (we resolve the full records below, but only the
+                # ids are guaranteed at this point — the FE already
+                # holds the filename/size from its own upload step).
+                attachments_meta = (
+                    [{"attachment_id": aid} for aid in attachments]
+                    if attachments else None
+                )
+                try:
+                    self.conversation_service.append_message(
+                        user_id=user_id,
+                        conversation_id=active_conversation_id,
+                        role="user",
+                        content=last_user_text or "",
+                        attachments_meta=attachments_meta,
+                    )
+                except Exception:
+                    self.logger.exception(
+                        "append user message failed for conv=%s",
+                        active_conversation_id,
+                    )
+                    # Don't bail — the SDK loop can still run; the
+                    # missing user-msg row is a non-fatal degradation
+                    # we'd rather surface to logs than block on.
+
             # ak-1x4: resolve attachments + spec-cap enforcement BEFORE
             # SDK setup. If anything fails we want to surface a single
             # clean error event and exit — no MCP server boot, no Claude
@@ -646,6 +762,31 @@ class AgentService(BaseService):
             if full_text:
                 yield self._sse_event("text", {"content": full_text})
 
+            # ak-bq5: persist the assistant message BEFORE yielding
+            # `done`. This way the read-back endpoint shows the full
+            # turn for any client that pings GET /agent/conversations/<id>
+            # the moment the FE marks the message as final. We mark
+            # persisted_assistant=True so the finally block doesn't
+            # double-save with partial=True.
+            if (
+                self.conversation_service is not None
+                and active_conversation_id is not None
+            ):
+                try:
+                    self.conversation_service.append_message(
+                        user_id=user_id,
+                        conversation_id=active_conversation_id,
+                        role="assistant",
+                        content=full_text or "",
+                        partial=False,
+                    )
+                    persisted_assistant = True
+                except Exception:
+                    self.logger.exception(
+                        "append assistant message failed for conv=%s",
+                        active_conversation_id,
+                    )
+
             # Done
             yield self._sse_event("done", {"mutations": mutations})
 
@@ -653,6 +794,41 @@ class AgentService(BaseService):
             self.logger.error(f"Agent error: {e}")
             yield self._sse_event("error", {"message": str(e)})
         finally:
+            # ak-bq5: if the SDK loop crashed OR the generator was
+            # closed early (FE disconnect after first text chunk),
+            # persisted_assistant is still False AND we've collected
+            # partial text. Save it with partial=True so the FE can
+            # render a "stream interrupted" badge.
+            #
+            # We only fire this in the conversation_service-wired path
+            # AND only when there's something worth saving (text or
+            # tool events). Empty-turn case is already handled by the
+            # happy path's v3 sentinel.
+            if (
+                self.conversation_service is not None
+                and active_conversation_id is not None
+                and not persisted_assistant
+            ):
+                partial_text = ""
+                try:
+                    partial_text = "".join(text_parts)
+                except Exception:
+                    partial_text = ""
+                if partial_text or tool_events:
+                    try:
+                        self.conversation_service.append_message(
+                            user_id=user_id,
+                            conversation_id=active_conversation_id,
+                            role="assistant",
+                            content=partial_text,
+                            partial=True,
+                        )
+                    except Exception:
+                        self.logger.exception(
+                            "append partial assistant message failed "
+                            "for conv=%s", active_conversation_id,
+                        )
+
             # ak-1x4: ephemeral per-turn cleanup. Best-effort rmtree of
             # any attachment subtrees this stream_chat call resolved (or
             # tried to resolve). Failures are swallowed inside
@@ -668,6 +844,26 @@ class AgentService(BaseService):
                         "attachment cleanup failed for %s (id=%s)",
                         user_id, att_id,
                     )
+
+    @staticmethod
+    def _extract_last_user_content(messages):
+        """ak-bq5: pull the most recent user message's content for
+        title derivation + persistence. Returns "" if absent or shaped
+        unexpectedly so callers can pass it directly to
+        derive_title (which itself falls back to a default)."""
+        if not messages:
+            return ""
+        # Scan from the end — the FE typically sends history with the
+        # newest user turn at messages[-1], but be tolerant of an
+        # `assistant`-trailing payload.
+        for msg in reversed(messages):
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("role") != "user":
+                continue
+            content = msg.get("content", "")
+            return content if isinstance(content, str) else str(content)
+        return ""
 
     def _build_sdk_tools(self, agent_type, tool_defs, user_id,
                          tool_events, mutations, confirmed_tools):

--- a/services/agentService.py
+++ b/services/agentService.py
@@ -397,8 +397,7 @@ class AgentService(BaseService):
         attachment_ids_to_cleanup = []
 
         try:
-            # ak-bq5: conversation_id pre-flight + persist user msg
-            # BEFORE any expensive SDK work. Three cases:
+            # ak-bq5: conversation_id pre-flight. Three cases:
             #
             # (a) no conversation_service wired → persistence OFF,
             #     legacy stateless behavior. Skip the whole block.
@@ -410,9 +409,15 @@ class AgentService(BaseService):
             #     emit the new id as the leading SSE event so the FE
             #     can pin it.
             #
-            # Then in all "on" cases we append the inbound user message
-            # so the read-back endpoint reflects the full thread even
-            # if the SDK crashes mid-stream.
+            # ak-bq5 pass-2 reviewer fix (hq-wisp-4tbck MAJOR): the
+            # user message is NO LONGER persisted here. We defer it
+            # until AFTER attachment_records is resolved so the row's
+            # attachments_meta carries full descriptors (filename,
+            # content_type, size) — not just the opaque id. On a
+            # second device the /tmp file is gone, so the metadata
+            # IS the only thing the FE has to render. See "user msg
+            # persist (deferred)" below.
+            last_user_text = ""
             if self.conversation_service is not None:
                 last_user_text = self._extract_last_user_content(messages)
                 if active_conversation_id is None:
@@ -458,34 +463,11 @@ class AgentService(BaseService):
                         return
 
                 # Emit the id as the leading SSE event so the FE can
-                # pin it for follow-up turns + persist the user message.
+                # pin it for follow-up turns. User message persistence
+                # is deferred — see below.
                 yield self._sse_event("conversation_id", {
                     "id": active_conversation_id,
                 })
-                # Build attachments_meta from the just-parsed attachment
-                # arg (we resolve the full records below, but only the
-                # ids are guaranteed at this point — the FE already
-                # holds the filename/size from its own upload step).
-                attachments_meta = (
-                    [{"attachment_id": aid} for aid in attachments]
-                    if attachments else None
-                )
-                try:
-                    self.conversation_service.append_message(
-                        user_id=user_id,
-                        conversation_id=active_conversation_id,
-                        role="user",
-                        content=last_user_text or "",
-                        attachments_meta=attachments_meta,
-                    )
-                except Exception:
-                    self.logger.exception(
-                        "append user message failed for conv=%s",
-                        active_conversation_id,
-                    )
-                    # Don't bail — the SDK loop can still run; the
-                    # missing user-msg row is a non-fatal degradation
-                    # we'd rather surface to logs than block on.
 
             # ak-1x4: resolve attachments + spec-cap enforcement BEFORE
             # SDK setup. If anything fails we want to surface a single
@@ -525,6 +507,51 @@ class AgentService(BaseService):
                         return
                     attachment_records.append(rec)
                     attachment_ids_to_cleanup.append(att_id)
+
+            # ak-bq5 pass-2 reviewer fix (hq-wisp-4tbck MAJOR): persist
+            # the inbound user message HERE — after attachment resolution
+            # has succeeded. attachments_meta now carries the full
+            # descriptor (id + filename + content_type + size) for each
+            # attachment, not just the bare id. When a second device
+            # reads the thread back, the /tmp file is gone (sweep ran),
+            # so the metadata IS the FE's only render source.
+            #
+            # If resolution failed we've already SSE-errored and
+            # returned above — we never reach this point with an
+            # invalid attachment ref, so a persisted user row with full
+            # descriptors is always trustworthy.
+            if (
+                self.conversation_service is not None
+                and active_conversation_id is not None
+            ):
+                attachments_meta = (
+                    [
+                        {
+                            "attachment_id": r.get("attachment_id"),
+                            "filename": r.get("filename"),
+                            "content_type": r.get("content_type"),
+                            "size": r.get("size"),
+                        }
+                        for r in attachment_records
+                    ]
+                    if attachment_records else None
+                )
+                try:
+                    self.conversation_service.append_message(
+                        user_id=user_id,
+                        conversation_id=active_conversation_id,
+                        role="user",
+                        content=last_user_text or "",
+                        attachments_meta=attachments_meta,
+                    )
+                except Exception:
+                    self.logger.exception(
+                        "append user message failed for conv=%s",
+                        active_conversation_id,
+                    )
+                    # Don't bail — the SDK loop can still run; the
+                    # missing user-msg row is a non-fatal degradation
+                    # we'd rather surface to logs than block on.
 
             config = get_agent_config(agent_type)
 

--- a/test_agent_conversations.py
+++ b/test_agent_conversations.py
@@ -1,0 +1,356 @@
+"""ak-bq5 — offline unit tests for cross-device agent chat persistence.
+
+Coverage:
+  - derive_title: empty / whitespace / short / long / multi-line input
+  - VALID_AGENT_TYPES contract
+  - Models: column shape sanity (table_args / FK / soft-delete column)
+  - Controller wiring: routes registered in app.py
+  - SSE leading event shape for the new conversation_id event
+
+Heavy DB-driven tests (cross-user isolation, soft-delete excluded from
+list, agent_type filter, auto-create-vs-reuse) are designed to run on
+infra against a real DB after deploy. The offline layer here exercises
+the pure-Python pieces + structural contracts.
+"""
+
+import os
+import re
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+
+# ── derive_title ─────────────────────────────────────────────────────────
+
+
+class TestDeriveTitle(unittest.TestCase):
+    """derive_title is dependency-free (just str / regex) so we can
+    import it directly without stubbing flask / sqlalchemy."""
+
+    def setUp(self):
+        # Lazy import avoids dragging models import-chain into other
+        # tests; if the module fails to import we skip the whole class.
+        try:
+            from services.agentConversationService import (
+                derive_title, DEFAULT_TITLE, TITLE_MAX_LEN,
+            )
+        except ImportError as e:
+            self.skipTest(f"agentConversationService not importable: {e}")
+            return
+        self.derive = derive_title
+        self.DEFAULT = DEFAULT_TITLE
+        self.MAX_LEN = TITLE_MAX_LEN
+
+    def test_empty_inputs_use_default(self):
+        print("\n[derive_title — empty / whitespace input → default]")
+        for raw in (None, "", "   ", "\n\n\t  ", 0, [], {}):
+            self.assertEqual(self.derive(raw), self.DEFAULT,
+                             f"expected default for {raw!r}")
+        print(f"  ✓ default title '{self.DEFAULT}' for empty inputs")
+
+    def test_short_input_passes_through(self):
+        print("\n[derive_title — short input passes through unchanged]")
+        out = self.derive("What's my EPF balance?")
+        self.assertEqual(out, "What's my EPF balance?")
+        self.assertNotIn("…", out)
+        print(f"  ✓ {out!r}")
+
+    def test_newlines_collapsed(self):
+        print("\n[derive_title — newlines + multi-space collapsed to single space]")
+        out = self.derive("Help me\n\n\nfix\tEPF\n entries")
+        self.assertEqual(out, "Help me fix EPF entries")
+        self.assertNotIn("\n", out)
+        self.assertNotIn("\t", out)
+        self.assertNotIn("  ", out)
+        print(f"  ✓ collapsed → {out!r}")
+
+    def test_long_input_truncated_at_word_boundary(self):
+        print("\n[derive_title — long input truncated at MAX_LEN with ellipsis]")
+        # 100-char message; expect truncation to ~MAX_LEN + ellipsis.
+        raw = ("Walk me through reconciling my April 2026 EPF passbook "
+               "entries against the Form 23A I just uploaded")
+        out = self.derive(raw)
+        # ellipsis added when truncation happens
+        self.assertTrue(out.endswith("…"))
+        # never longer than MAX_LEN + 1 (the ellipsis)
+        self.assertLessEqual(len(out), self.MAX_LEN + 1)
+        # whatever is kept must be a prefix of the cleaned input (sans
+        # ellipsis), so the title remains anchored in the user's words
+        self.assertTrue(raw.startswith(out.rstrip("…")))
+        print(f"  ✓ truncated ({len(out)} chars): {out!r}")
+
+    def test_non_string_input_uses_default(self):
+        print("\n[derive_title — non-string input → default]")
+        # Defensive: list, dict, int all return default rather than
+        # str()-ing into a weird title.
+        self.assertEqual(self.derive(["hi"]), self.DEFAULT)
+        self.assertEqual(self.derive({"role": "user"}), self.DEFAULT)
+        self.assertEqual(self.derive(42), self.DEFAULT)
+        print("  ✓ non-string returns default")
+
+
+class TestValidAgentTypes(unittest.TestCase):
+    def test_contract_matches_controllers(self):
+        print("\n[VALID_AGENT_TYPES — matches controllers/agentEP.py]")
+        try:
+            from services.agentConversationService import VALID_AGENT_TYPES
+        except ImportError as e:
+            self.skipTest(f"agentConversationService not importable: {e}")
+            return
+        # Sanity: the three agent types known to agentEP.chat() validate.
+        self.assertEqual(
+            set(VALID_AGENT_TYPES),
+            {"investment", "transaction", "freelance"},
+        )
+        print(f"  ✓ {VALID_AGENT_TYPES}")
+
+
+# ── Model structural sanity ──────────────────────────────────────────────
+
+
+class TestModelStructure(unittest.TestCase):
+    """The model files declare table_args + columns we rely on for the
+    list query + soft-delete filter. Verify by reading the source — the
+    real ORM materialization happens via db.create_all() in prod, but
+    structural review catches drift offline."""
+
+    @classmethod
+    def setUpClass(cls):
+        repo = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(repo, "models", "AgentConversation.py")) as fh:
+            cls.conv_src = fh.read()
+        with open(os.path.join(repo, "models", "AgentMessage.py")) as fh:
+            cls.msg_src = fh.read()
+
+    def test_conversation_has_soft_delete_column(self):
+        print("\n[AgentConversation — deleted_at column present]")
+        self.assertIn("deleted_at = Column", self.conv_src)
+        self.assertIn("nullable=True", self.conv_src)
+        print("  ✓ deleted_at nullable")
+
+    def test_conversation_has_compound_index(self):
+        print("\n[AgentConversation — (user_id, agent_type, updated_at) index]")
+        # Index name + composed columns (order matters for the ORDER BY)
+        self.assertIn("ix_agent_conv_user_type_updated", self.conv_src)
+        self.assertRegex(
+            self.conv_src,
+            r"'user_id',\s*'agent_type',\s*'updated_at'",
+        )
+        print("  ✓ compound index supports list query")
+
+    def test_conversation_fk_to_users_cascade(self):
+        print("\n[AgentConversation — user_id FK with CASCADE]")
+        self.assertRegex(
+            self.conv_src,
+            r"ForeignKey\('users\.userID',\s*ondelete='CASCADE'\)",
+        )
+        print("  ✓ CASCADE on user delete")
+
+    def test_message_role_constants_match_dispatch(self):
+        print("\n[AgentMessage — AGENT_MESSAGE_ROLES matches dispatch contract]")
+        self.assertIn("AGENT_MESSAGE_ROLES = ('user', 'assistant', 'tool')",
+                      self.msg_src)
+        print("  ✓ user / assistant / tool")
+
+    def test_message_has_attachments_meta_json(self):
+        print("\n[AgentMessage — attachments_meta JSON nullable]")
+        self.assertRegex(
+            self.msg_src,
+            r"attachments_meta\s*=\s*Column\(JSON,\s*nullable=True\)",
+        )
+        print("  ✓ JSON nullable column present")
+
+    def test_message_partial_default_false(self):
+        print("\n[AgentMessage — partial defaults to FALSE]")
+        # ORM default + server_default both False so a row coming in via
+        # raw SQL (e.g. migration backfill) also lands False.
+        self.assertIn("default=False", self.msg_src)
+        self.assertIn("server_default='0'", self.msg_src)
+        print("  ✓ partial defaults False")
+
+    def test_message_fk_cascade_to_conversation(self):
+        print("\n[AgentMessage — conversation_id FK with CASCADE]")
+        self.assertRegex(
+            self.msg_src,
+            r"ForeignKey\('agent_conversations\.id',\s*ondelete='CASCADE'\)",
+        )
+        print("  ✓ CASCADE on conversation delete")
+
+
+# ── Controller wiring sanity ─────────────────────────────────────────────
+
+
+class TestRouteWiring(unittest.TestCase):
+    """Routes registered in app.py drive the entire BE surface. If a
+    route gets dropped during a refactor, the FE silently 404s. These
+    checks live in source-only verification so they don't need a Flask
+    boot to catch the regression."""
+
+    @classmethod
+    def setUpClass(cls):
+        repo = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(repo, "app.py")) as fh:
+            cls.app_src = fh.read()
+
+    def test_list_route_registered(self):
+        print("\n[app.py — GET /agent/conversations route present]")
+        self.assertRegex(
+            self.app_src,
+            r"\('/agent/conversations',\s*'GET',\s*self\.agentConversationsEP\.list\)",
+        )
+        print("  ✓ GET list")
+
+    def test_create_route_registered(self):
+        print("\n[app.py — POST /agent/conversations route present]")
+        self.assertRegex(
+            self.app_src,
+            r"\('/agent/conversations',\s*'POST',\s*self\.agentConversationsEP\.create\)",
+        )
+        print("  ✓ POST create")
+
+    def test_get_route_registered(self):
+        print("\n[app.py — GET /agent/conversations/<id> route present]")
+        self.assertRegex(
+            self.app_src,
+            r"\('/agent/conversations/<conversation_id>',\s*'GET',\s*self\.agentConversationsEP\.get\)",
+        )
+        print("  ✓ GET single")
+
+    def test_delete_route_registered(self):
+        print("\n[app.py — DELETE /agent/conversations/<id> route present]")
+        self.assertRegex(
+            self.app_src,
+            r"\('/agent/conversations/<conversation_id>',\s*'DELETE',\s*self\.agentConversationsEP\.delete\)",
+        )
+        print("  ✓ DELETE soft")
+
+    def test_conversation_service_wired_into_agent_service(self):
+        print("\n[app.py — conversation_service passed to AgentService.set_services]")
+        self.assertIn(
+            "conversation_service=self.agentConversationService",
+            self.app_src,
+        )
+        print("  ✓ AgentService receives conversation_service")
+
+
+# ── /agent/chat shape ────────────────────────────────────────────────────
+
+
+class TestChatControllerShape(unittest.TestCase):
+    """The chat() handler now accepts conversation_id in the body and
+    forwards it to stream_chat. Verify via source inspection."""
+
+    @classmethod
+    def setUpClass(cls):
+        repo = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(repo, "controllers", "agentEP.py")) as fh:
+            cls.src = fh.read()
+
+    def test_chat_accepts_conversation_id(self):
+        print("\n[agentEP.chat — accepts conversation_id from body]")
+        self.assertIn('conversation_id = data.get("conversation_id")', self.src)
+        print("  ✓ conversation_id read")
+
+    def test_chat_forwards_to_stream_chat(self):
+        print("\n[agentEP.chat — forwards conversation_id to stream_chat]")
+        self.assertIn("conversation_id=conversation_id,", self.src)
+        print("  ✓ forwarded")
+
+    def test_chat_rejects_non_int_conversation_id(self):
+        print("\n[agentEP.chat — non-int conversation_id → 400]")
+        self.assertIn(
+            'conversation_id must be an integer',
+            self.src,
+        )
+        print("  ✓ int coercion enforced")
+
+
+# ── stream_chat SSE event ────────────────────────────────────────────────
+
+
+class TestStreamChatSSEEvent(unittest.TestCase):
+    """stream_chat must emit a leading {type:conversation_id, id:int}
+    event so the FE can pin the id before any text streams in."""
+
+    @classmethod
+    def setUpClass(cls):
+        repo = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(repo, "services", "agentService.py")) as fh:
+            cls.src = fh.read()
+
+    def test_leading_conversation_id_event_emitted(self):
+        print("\n[agentService — emits SSE conversation_id event]")
+        self.assertIn(
+            'yield self._sse_event("conversation_id"',
+            self.src,
+        )
+        print("  ✓ event present in stream loop")
+
+    def test_assistant_persist_on_success(self):
+        print("\n[agentService — append_message(role='assistant', partial=False) on success]")
+        # Look for the canonical success-path persist call shape
+        self.assertRegex(
+            self.src,
+            r'role="assistant",\s*\n\s*content=full_text or "",\s*\n\s*partial=False,',
+        )
+        print("  ✓ assistant message persisted before `done` yield")
+
+    def test_partial_assistant_persist_in_finally(self):
+        print("\n[agentService — partial=True persist in finally block]")
+        # Source markers for the partial-save path
+        self.assertIn("not persisted_assistant", self.src)
+        self.assertIn("partial=True", self.src)
+        print("  ✓ partial save guarded by persisted_assistant flag")
+
+
+# ── Service-layer scope guard contract ───────────────────────────────────
+
+
+class TestServiceScopeGuards(unittest.TestCase):
+    """Every read / write path must go through _fetch_owned so the
+    cross-user check has a single source of truth. Verifying via source
+    inspection (heavy DB-level cross-user isolation tests run on infra
+    against a real DB)."""
+
+    @classmethod
+    def setUpClass(cls):
+        repo = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(repo, "services", "agentConversationService.py")) as fh:
+            cls.src = fh.read()
+
+    def test_fetch_owned_filters_user_and_soft_delete(self):
+        print("\n[_fetch_owned — filters by user_id AND deleted_at IS NULL]")
+        self.assertIn("AgentConversation.user_id == user_id", self.src)
+        self.assertIn("AgentConversation.deleted_at.is_(None)", self.src)
+        print("  ✓ both filters present in helper")
+
+    def test_get_and_delete_use_fetch_owned(self):
+        print("\n[get_conversation + soft_delete + append_message use _fetch_owned]")
+        # Count call sites — should be at least three (get / append / soft_delete)
+        callsites = re.findall(r"self\._fetch_owned\(", self.src)
+        self.assertGreaterEqual(len(callsites), 3,
+                                f"expected ≥3 _fetch_owned calls, got {len(callsites)}")
+        print(f"  ✓ {len(callsites)} membership-check call sites")
+
+    def test_list_filters_user_and_soft_delete(self):
+        print("\n[list_conversations — filters user_id AND deleted_at IS NULL]")
+        self.assertIn("AgentConversation.user_id == user_id", self.src)
+        # list_conversations has its own deleted_at filter (doesn't go
+        # through _fetch_owned)
+        self.assertRegex(
+            self.src,
+            r"\.filter\(AgentConversation\.deleted_at\.is_\(None\)\)",
+        )
+        print("  ✓ list query filtered by both")
+
+
+# ── Runner ───────────────────────────────────────────────────────────────
+
+
+if __name__ == "__main__":
+    print("ak-bq5 agent conversations — offline unit tests")
+    print("=" * 70)
+    unittest.main(verbosity=0, exit=False)
+    print("=" * 70)
+    print("Done.")

--- a/test_agent_conversations.py
+++ b/test_agent_conversations.py
@@ -307,6 +307,102 @@ class TestStreamChatSSEEvent(unittest.TestCase):
 # ── Service-layer scope guard contract ───────────────────────────────────
 
 
+class TestAttachmentsMetaFullDescriptor(unittest.TestCase):
+    """ak-bq5 pass-2 reviewer fix (hq-wisp-4tbck MAJOR): the persisted
+    user message MUST carry the resolved descriptor (filename,
+    content_type, size) per attachment, not just the opaque id. On a
+    second device the /tmp file is gone; the metadata is the FE's only
+    render source.
+
+    Verified via source inspection of the stream_chat shape so we don't
+    need to boot Flask/SDK for the assertion."""
+
+    @classmethod
+    def setUpClass(cls):
+        repo = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(repo, "services", "agentService.py")) as fh:
+            cls.src = fh.read()
+        with open(os.path.join(repo, "models", "AgentMessage.py")) as fh:
+            cls.model_src = fh.read()
+
+    def test_attachments_meta_built_from_resolved_records(self):
+        print("\n[agentService — attachments_meta built from attachment_records]")
+        # The post-fix shape iterates over attachment_records (the
+        # resolved list with full descriptors), NOT over the bare
+        # attachments arg.
+        self.assertRegex(
+            self.src,
+            r"for r in attachment_records",
+            "attachments_meta should iterate the resolved records list",
+        )
+        # Each descriptor includes the four reviewer-required keys.
+        for key in ("attachment_id", "filename", "content_type", "size"):
+            self.assertRegex(
+                self.src,
+                rf'"{key}":\s*r\.get\("{key}"\)',
+                f"attachments_meta descriptor must include {key!r}",
+            )
+        print("  ✓ resolved-record iteration + full descriptor keys")
+
+    def test_bare_id_attachments_meta_removed(self):
+        print("\n[agentService — bare-id attachments_meta shape removed]")
+        # The pass-1 shape was a list comprehension over `attachments`
+        # (the bare-id list) — that's the MAJOR bug. Make sure it
+        # doesn't sneak back in.
+        self.assertNotRegex(
+            self.src,
+            r'\[\{"attachment_id":\s*aid\}\s*for\s*aid\s*in\s*attachments\]',
+            "bare-id attachments_meta shape must not return",
+        )
+        print("  ✓ pass-1 bare-id list comprehension is gone")
+
+    def test_user_persist_after_attachment_resolution(self):
+        print("\n[agentService — user-msg persist is downstream of attachment resolution]")
+        # Sanity ordering: the append_message(role='user', ...) call
+        # MUST appear AFTER the "for att_id in attachments:" resolution
+        # loop. If it returns to the pre-resolution position we lose
+        # the resolved-descriptor guarantee.
+        resolve_loop_pos = self.src.find("for att_id in attachments:")
+        user_persist_pos = self.src.find('role="user",')
+        self.assertGreater(
+            resolve_loop_pos, 0, "resolve loop must exist in source",
+        )
+        self.assertGreater(
+            user_persist_pos, 0, "user-msg persist call must exist",
+        )
+        self.assertGreater(
+            user_persist_pos, resolve_loop_pos,
+            "user-msg persist must come AFTER attachment resolution loop",
+        )
+        print("  ✓ persist is downstream of resolve")
+
+    def test_model_docstring_no_sha256_claim(self):
+        print("\n[AgentMessage.py — no implied sha256 claim in column comment]")
+        # The column comment previously promised sha256 in attachments_meta
+        # but we don't compute it. Reviewer flagged the implied claim.
+        # The post-fix comment lists what we DO carry and notes sha256
+        # as a follow-up.
+        # Column comment lists the 4 keys we actually persist.
+        for key in ("attachment_id", "filename", "content_type", "size"):
+            self.assertIn(key, self.model_src,
+                          f"attachments_meta comment should mention {key}")
+        # If sha256 still appears, it must be clearly flagged as
+        # follow-up / not-computed — not promised as part of the
+        # current shape. Accept either "not currently computed",
+        # "isn't computed", "follow-up", or "not yet" phrasing.
+        if "sha256" in self.model_src:
+            lowered = self.model_src.lower()
+            disclaimers = ("not currently computed", "isn't computed",
+                           "is not currently computed", "follow-up",
+                           "not yet")
+            has_disclaimer = any(d in lowered for d in disclaimers)
+            self.assertTrue(
+                has_disclaimer,
+                "sha256 still appears but isn't disclaimed as TBD",
+            )
+        print("  ✓ docstring reflects what we actually persist")
+
+
 class TestServiceScopeGuards(unittest.TestCase):
     """Every read / write path must go through _fetch_owned so the
     cross-user check has a single source of truth. Verifying via source


### PR DESCRIPTION
ak-bq5 — cross-device agent chat persistence. Adds agent_conversations + agent_messages tables, 4 endpoints (GET/POST/DELETE /agent/conversations + nested GET), /agent/chat accepts optional conversation_id + emits leading SSE conversation_id, persists user+assistant msgs; attachment descriptors stored metadata-only. Reviewer pass-2 CLEAR 0/0/1 (ak-eco P3 deferred). NO alembic — db.create_all() materializes tables on app restart post-deploy.