### PR TITLE
fix(mail): subdomain-blind domain classifier stamped bank=UNKNOWN (ak-x6p)

### DIFF
--- a/services/bankFormatRules.py
+++ b/services/bankFormatRules.py
@@ -81,11 +81,77 @@ def get_bank_from_sender(sender_email):
 
     Returns:
         Bank identifier string (e.g. 'HDFC_DEBIT') or 'UNKNOWN'
+
+    ak-x6p fix (hq-wisp-i30l3w): banks increasingly send from
+    subdomain-prefixed addresses (`alerts.bankofindia.bank.in`,
+    `noreply.hdfcbank.com`, etc.) that don't hit exact match against
+    DOMAIN_TO_BANK's canonical keys. Post-fix we try exact match
+    FIRST (backward-compatible), then a dot-boundary suffix match
+    to resolve subdomain-prefixed senders to their base bank.
+
+    The BOI backfill (ak-5oi) surfaced this: BOI's new sender is
+    `noreply-estatement@alerts.bankofindia.bank.in`, and the
+    domain-lookup returned "UNKNOWN". Downstream that "UNKNOWN"
+    hint got injected into the LLM prompt ("Use bank=\"UNKNOWN\"...")
+    and stamped onto fileDetails.bank — the visible ak-x6p symptom.
     """
     if "@" not in sender_email:
         return "UNKNOWN"
     domain = sender_email.split("@")[-1].strip().rstrip(">").lower()
-    return DOMAIN_TO_BANK.get(domain, "UNKNOWN")
+    # Exact match — preserves prior behavior for senders whose
+    # domain IS the canonical key (e.g. `noreply@hdfcbank.net`).
+    if domain in DOMAIN_TO_BANK:
+        return DOMAIN_TO_BANK[domain]
+    # Dot-boundary suffix match — resolves `alerts.<canonical>`,
+    # `noreply.<canonical>`, `mail.<canonical>`, etc. The leading dot
+    # requirement prevents `evilbankofindia.bank.in` from silently
+    # matching `bankofindia.bank.in`.
+    for known_domain, bank_id in DOMAIN_TO_BANK.items():
+        if domain.endswith("." + known_domain):
+            return bank_id
+    return "UNKNOWN"
+
+
+def get_banks_for_domain(sender_domain):
+    """List of possible bank identifiers for a raw domain string.
+
+    Used by mailProcessorService's password-lookup helpers, which
+    historically maintained their own inline domain→bank maps in
+    two places (lines 1122 + 1150 of mailProcessorService.py).
+    Same subdomain-blind problem as get_bank_from_sender: the sender
+    `alerts.bankofindia.bank.in` misses the map's `bankofindia.bank.in`
+    key. Returning a suffix-tolerant list here lets those callers
+    stop duplicating the map data.
+
+    Returns a list because a single canonical domain can host
+    multiple bank identifiers (e.g. hdfcbank.net covers HDFC_DEBIT,
+    Millenia_Credit, HDFC_REGALIA — the callers need to try each
+    password key in turn). We preserve the original insertion order
+    of DOMAIN_TO_BANK so existing "which bank to try first" behavior
+    isn't perturbed.
+
+    ak-x6p fix (hq-wisp-i30l3w): also fixes the parallel password-
+    lookup subdomain miss.
+    """
+    if not sender_domain:
+        return []
+    domain = sender_domain.strip().rstrip(">").lower()
+    if not domain:
+        return []
+    matched = []
+    # Exact match — walk DOMAIN_TO_BANK preserving insertion order so
+    # callers that want "closest sibling first" (e.g. try the primary
+    # HDFC_DEBIT password before Millenia_Credit) still get that.
+    for known_domain, bank_id in DOMAIN_TO_BANK.items():
+        if domain == known_domain and bank_id not in matched:
+            matched.append(bank_id)
+    if matched:
+        return matched
+    # Suffix match — same dot-boundary rule as get_bank_from_sender.
+    for known_domain, bank_id in DOMAIN_TO_BANK.items():
+        if domain.endswith("." + known_domain) and bank_id not in matched:
+            matched.append(bank_id)
+    return matched
 
 
 def get_format_rules(bank):

--- a/services/mailProcessorService.py
+++ b/services/mailProcessorService.py
@@ -322,6 +322,43 @@ class MailProcessorService:
             return at_part.strip().rstrip(">").lower()
         return ""
 
+    @staticmethod
+    def _lookup_domain_map(domain_map, sender_domain):
+        """Subdomain-aware lookup against a {domain: [bank_ids]} map.
+
+        ak-x6p fix (hq-wisp-i30l3w): the password-lookup helpers below
+        maintain their own local dicts (they carry per-domain
+        bank-order hints that differ from bankFormatRules.DOMAIN_TO_BANK,
+        so we don't consolidate them). Historically both hit sender's
+        raw domain against the map with exact match — which misses
+        subdomain-prefixed senders like `alerts.bankofindia.bank.in`.
+
+        Now:
+          - Exact match first (backward-compatible: preserves the
+            ordered list of bank ids the map author encoded).
+          - Dot-boundary suffix match otherwise, so
+            `alerts.bankofindia.bank.in` resolves to
+            `bankofindia.bank.in`'s entry list.
+        Returns a list of bank ids or [] if unresolved.
+        """
+        if not sender_domain:
+            return []
+        domain = sender_domain.strip().rstrip(">").lower()
+        if not domain:
+            return []
+        # Exact match — preserves prior ordering + behavior for
+        # senders whose domain IS a canonical key.
+        exact = domain_map.get(domain)
+        if exact:
+            return list(exact)
+        # Dot-boundary suffix match — same rule get_bank_from_sender
+        # uses. Guards `evilbank.foo.bank.in` from silently matching
+        # `foo.bank.in`.
+        for known_domain, bank_ids in domain_map.items():
+            if domain.endswith("." + known_domain):
+                return list(bank_ids)
+        return []
+
     # ── Agent-1: Claude-powered classification ─────────────────────
 
     def _classify_emails(self, all_emails):
@@ -917,8 +954,15 @@ class MailProcessorService:
             sender = email.get("sender", "")
             domain = self._extract_domain(sender)
 
-            # Currently only handles HDFC Smart Statements
-            if domain not in ("hdfcbank.net", "hdfcbank.com", "hdfcbank.bank.in"):
+            # Currently only handles HDFC Smart Statements. ak-x6p fix:
+            # dot-boundary suffix match so subdomain senders like
+            # `alerts.hdfcbank.bank.in` still route through the Smart
+            # Statement extractor (prior exact-match would silently
+            # skip them).
+            _hdfc_domains = ("hdfcbank.net", "hdfcbank.com", "hdfcbank.bank.in")
+            if domain not in _hdfc_domains and not any(
+                domain.endswith("." + d) for d in _hdfc_domains
+            ):
                 return None
 
             # Fetch full message to get HTML body
@@ -1124,7 +1168,9 @@ class MailProcessorService:
                 "hdfcbank.com": ["HDFC_DEBIT", "Millenia_Credit", "HDFC_REGALIA"],
                 "hdfcbank.bank.in": ["HDFC_DEBIT", "Millenia_Credit", "HDFC_REGALIA"],
             }
-            bank_names = domain_to_bank.get(domain, [])
+            # ak-x6p fix: subdomain-aware lookup (alerts.hdfcbank.bank.in
+            # etc.); prior `.get(domain, [])` missed these.
+            bank_names = self._lookup_domain_map(domain_to_bank, domain)
             for bank_name in bank_names:
                 pw = self.transaction_service.db.session.query(StatementPasswords).filter_by(
                     user=user_id, bank=bank_name
@@ -1167,7 +1213,10 @@ class MailProcessorService:
         explicit_passwords = []
         try:
             from models import StatementPasswords
-            bank_names = domain_to_bank.get(domain, [])
+            # ak-x6p fix: subdomain-aware lookup so senders like
+            # `noreply-estatement@alerts.bankofindia.bank.in` still
+            # resolve to the BOI password candidates.
+            bank_names = self._lookup_domain_map(domain_to_bank, domain)
             for bank_name in bank_names:
                 pw = self.transaction_service.db.session.query(StatementPasswords).filter_by(
                     user=user_id, bank=bank_name

--- a/test_bank_format_rules.py
+++ b/test_bank_format_rules.py
@@ -1,0 +1,169 @@
+"""ak-x6p regression tests for services/bankFormatRules.py.
+
+Root cause of the ak-x6p bug (fileDetails.bank=UNKNOWN for BOI
+statements even though the ak-2ql domain-map was updated) was
+`get_bank_from_sender` doing an EXACT match against DOMAIN_TO_BANK:
+the resolved sender domain `alerts.bankofindia.bank.in` never
+matched `bankofindia.bank.in` in the map, so downstream stamped
+"UNKNOWN" on both the LLM prompt hint AND (via the same variable)
+the fileDetails row.
+
+These tests lock in the subdomain-suffix match so a future
+regression re-opens loudly. Pure-Python; no framework deps.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from services.bankFormatRules import (
+    DOMAIN_TO_BANK,
+    get_bank_from_sender,
+    get_banks_for_domain,
+)
+
+
+class TestGetBankFromSenderExactMatch(unittest.TestCase):
+    """Backward-compatibility: exact-match callers keep working."""
+
+    def test_hdfc_canonical(self):
+        self.assertEqual(
+            get_bank_from_sender("noreply@hdfcbank.net"), "HDFC_DEBIT",
+        )
+
+    def test_boi_legacy(self):
+        # Pre-ak-2ql BOI domain still works.
+        self.assertEqual(
+            get_bank_from_sender("estatements@bankofindia.co.in"), "BOI",
+        )
+
+    def test_boi_bank_in(self):
+        # ak-2ql-added .bank.in root domain (exact, no subdomain).
+        self.assertEqual(
+            get_bank_from_sender("noreply@bankofindia.bank.in"), "BOI",
+        )
+
+    def test_no_at_sign_returns_unknown(self):
+        self.assertEqual(get_bank_from_sender("noatsignhere"), "UNKNOWN")
+
+    def test_wrapped_email(self):
+        # "Display Name <email@domain>" format.
+        self.assertEqual(
+            get_bank_from_sender("Bank of India <noreply@bankofindia.co.in>"),
+            "BOI",
+        )
+
+
+class TestGetBankFromSenderSubdomain(unittest.TestCase):
+    """ak-x6p fix: subdomain-suffix match resolves alerts.<canonical>."""
+
+    def test_boi_alerts_subdomain(self):
+        """The specific case from the ak-5oi backfill: BOI's new
+        estatement sender uses an `alerts.` subdomain prefix."""
+        self.assertEqual(
+            get_bank_from_sender(
+                "noreply-estatement@alerts.bankofindia.bank.in",
+            ),
+            "BOI",
+        )
+
+    def test_hdfc_alerts_subdomain(self):
+        self.assertEqual(
+            get_bank_from_sender("foo@alerts.hdfcbank.bank.in"),
+            "HDFC_DEBIT",
+        )
+
+    def test_yes_bank_mail_subdomain(self):
+        self.assertEqual(
+            get_bank_from_sender("x@mail.yesbank.in"),
+            "YES_BANK_DEBIT",
+        )
+
+    def test_deep_subdomain(self):
+        # Multi-level subdomain still matches on the base.
+        self.assertEqual(
+            get_bank_from_sender("y@a.b.c.hdfcbank.net"),
+            "HDFC_DEBIT",
+        )
+
+    def test_dot_boundary_guard(self):
+        """Non-boundary substring match must NOT resolve.
+        `evilbankofindia.bank.in` is NOT `bankofindia.bank.in` even
+        though the raw string endswith it — the leading dot is
+        required to prevent hijacking."""
+        self.assertEqual(
+            get_bank_from_sender("bad@evilbankofindia.bank.in"),
+            "UNKNOWN",
+        )
+
+    def test_no_match_still_unknown(self):
+        self.assertEqual(
+            get_bank_from_sender("nobody@nowhere.example"),
+            "UNKNOWN",
+        )
+
+    def test_wrapped_subdomain_email(self):
+        self.assertEqual(
+            get_bank_from_sender(
+                "BOI <noreply-estatement@alerts.bankofindia.bank.in>",
+            ),
+            "BOI",
+        )
+
+
+class TestGetBanksForDomain(unittest.TestCase):
+    """The new suffix-tolerant lookup helper used by password-lookup
+    call sites in mailProcessorService.py."""
+
+    def test_exact_hit(self):
+        result = get_banks_for_domain("bankofindia.bank.in")
+        self.assertEqual(result, ["BOI"])
+
+    def test_subdomain_hit(self):
+        result = get_banks_for_domain("alerts.bankofindia.bank.in")
+        self.assertEqual(result, ["BOI"])
+
+    def test_empty(self):
+        self.assertEqual(get_banks_for_domain(""), [])
+        self.assertEqual(get_banks_for_domain(None), [])
+
+    def test_no_match(self):
+        self.assertEqual(get_banks_for_domain("nowhere.example"), [])
+
+    def test_dot_boundary_guard(self):
+        # Same guard as get_bank_from_sender — non-boundary suffix
+        # must not resolve.
+        self.assertEqual(
+            get_banks_for_domain("evilbankofindia.bank.in"), [],
+        )
+
+    def test_trailing_bracket_stripped(self):
+        # Callers may pass "alerts.bankofindia.bank.in>" from a
+        # partially-parsed sender header; helper strips gracefully.
+        self.assertEqual(
+            get_banks_for_domain("alerts.bankofindia.bank.in>"),
+            ["BOI"],
+        )
+
+
+class TestDomainToBankShape(unittest.TestCase):
+    """Sanity that DOMAIN_TO_BANK still contains the ak-2ql-critical
+    entries so the .bank.in TLD migration doesn't accidentally
+    regress out of the map."""
+
+    def test_boi_bank_in_present(self):
+        self.assertEqual(DOMAIN_TO_BANK.get("bankofindia.bank.in"), "BOI")
+
+    def test_hdfc_bank_in_present(self):
+        self.assertEqual(
+            DOMAIN_TO_BANK.get("hdfcbank.bank.in"), "HDFC_DEBIT",
+        )
+
+
+if __name__ == "__main__":
+    print("ak-x6p bankFormatRules regression tests")
+    print("=" * 60)
+    unittest.main(verbosity=2, exit=False)
+    print("=" * 60)


### PR DESCRIPTION
ak-x6p — get_bank_from_sender did EXACT match against DOMAIN_TO_BANK, so BOI's alerts.bankofindia.bank.in (subdomain of ak-2ql's key) returned UNKNOWN, poisoning the LLM classifier hint + password dicts. Fix: exact match first (backward-compat) + dot-boundary suffix fallback across bankFormatRules + mailProcessor password dicts + HDFC link extractor. 20 tests incl dot-boundary guard. Reviewer 0/0/1 (ak-svr deferred). Adversarial probes (evilbankofindia.bank.in, suffix-injection) rejected.