### PR TITLE
feat(extractor): HDFC combined-statement section filter + file-level reconciliation backstop (ak-ifc)

### DIFF
--- a/models/fileDetails.py
+++ b/models/fileDetails.py
@@ -15,6 +15,21 @@ class FileDetails(Base):
     user = Column(String(100), ForeignKey('users.userID', ondelete='CASCADE'), nullable=False)
     gmail_message_id = Column(String(500), nullable=True, unique=True)  # Email Message-Id header for statement emails
     deleted = Column(Boolean, nullable=False, default=False, server_default='0')  # Soft delete flag
+    # ak-ifc v3 MINOR 1: when the file-level savings-summary
+    # reconciliation backstop detects divergence between extracted
+    # savings totals and the PDF's own summary, it falls back to
+    # unfiltered extraction (over-parse trade for zero-loss). This
+    # flag lets a follow-up sweep find these files for manual review
+    # of the acknowledged non-savings contamination.
+    #
+    # MIGRATION: infra needs an ALTER TABLE fileDetails ADD COLUMN
+    # reconciliation_fallback BOOLEAN NOT NULL DEFAULT 0; before this
+    # deploys. Until then, TransactionService.mark_reconciliation_fallback
+    # swallows the ORM error so the fallback re-run still lands the
+    # data.
+    reconciliation_fallback = Column(
+        Boolean, nullable=False, default=False, server_default='0',
+    )
 
     transactions = relationship('Transactions', back_populates='file_details')
     user_relationship = relationship('User', back_populates='file_details')

--- a/services/mailProcessorService.py
+++ b/services/mailProcessorService.py
@@ -1620,12 +1620,204 @@ class MailProcessorService:
                 self.logger.warning(
                     f"Failed chunks (retry with only_chunks): {failed_chunks}"
                 )
+
+            # ── ak-ifc v3: file-level savings-summary reconciliation ──
+            # After ALL chunks have inserted, compare the aggregate
+            # extracted totals to the PDF's own savings summary. If
+            # they diverge, re-run every chunk with force_no_mask=True
+            # so partially-missed savings rows are recovered. This is
+            # the whole point of the ak-ifc effort — hoisting from
+            # v2's per-chunk gate (which only fired on ≤2 page files)
+            # to file scope means combined statements (always > 2
+            # pages) actually get protection.
+            if processing_mode == "text":
+                await self._run_hdfc_file_level_reconciliation(
+                    pdf_path, email, user_id, password,
+                    total_pages, file_id, chunks, text_mode_options,
+                )
         except Exception as e:
             self.logger.error(
                 f"PDF chunk processing error: {e}"
             )
         finally:
             pass  # query() manages its own lifecycle per chunk
+
+    async def _run_hdfc_file_level_reconciliation(
+        self, pdf_path, email, user_id, password,
+        total_pages, file_id, chunks, text_mode_options,
+    ):
+        """ak-ifc v3 MAJOR: file-scope reconciliation backstop.
+
+        Reviewer's proposal (BOUNCE ak-ifc-v3):
+
+          After all chunks of a text-mode HDFC_DEBIT run have inserted:
+            (a) Aggregate extracted savings totals from the DB
+                (all rows for this fileID+user).
+            (b) Parse the file's savings summary from the FULL raw
+                text (not chunk-scoped).
+            (c) check_hdfc_savings_reconciliation with default ₹1
+                tolerance.
+            (d) IF divergent:
+                - WARN with structured fields (fileID, extracted_*,
+                  stated_*, delta, num_chunks).
+                - Mark fileDetails.reconciliation_fallback = True so
+                  a follow-up sweep can flag the file for manual
+                  review of the acknowledged over-parse.
+                - Re-run every chunk with force_no_mask=True. The
+                  ak-8l5-v2 storage-layer backstop handles the
+                  redundant inserts (existing rows collapse via
+                  primary hash; missed rows land).
+            (e) IF summary missing: log SKIP, no fallback.
+            (f) IF clean: log OK, no action.
+
+        Skipped when detected_bank != HDFC_DEBIT — this backstop is
+        HDFC-specific and there's no BOI equivalent yet (BOI's own
+        combined-statement follow-up is tracked separately).
+        """
+        import fitz as _fitz
+        from services.bankFormatRules import get_bank_from_sender
+        from models.transactions import Transactions
+        from sqlalchemy import func as sa_func
+        from utils.statement_sections import (
+            check_hdfc_reconciliation_from_totals,
+            detect_hdfc_sections,
+            parse_hdfc_savings_summary,
+        )
+
+        detected_bank = email.get("_bank") or get_bank_from_sender(
+            email.get("sender", "")
+        )
+        if detected_bank != "HDFC_DEBIT":
+            return  # nothing to reconcile
+
+        # Read the full raw text (unmasked) to parse the summary and
+        # detect spans. This is a fresh open — cheaper than plumbing
+        # the earlier per-chunk doc reference.
+        try:
+            doc = _fitz.open(pdf_path)
+            if doc.needs_pass and password:
+                doc.authenticate(password)
+            full_lines = []
+            for pn in range(1, doc.page_count + 1):
+                # Marker line matches _compute_hdfc_section_keep_mask
+                # so span indices are consistent (defensive — we don't
+                # index across the two here, but keeps the shape).
+                full_lines.append(f"\f<PAGE:{pn}>")
+                page_text = doc[pn - 1].get_text("text")
+                full_lines.extend(page_text.split("\n"))
+            doc.close()
+        except Exception as e:
+            self.logger.warning(
+                f"ak-ifc file-reconciliation: could not read PDF for "
+                f"summary parse (file={file_id!r}): {e}. Skipping."
+            )
+            return
+
+        full_text = "\n".join(full_lines)
+        spans = detect_hdfc_sections(full_text)
+        summary = parse_hdfc_savings_summary(full_text, spans=spans)
+
+        # Aggregate extracted totals from the DB for this fileID+user.
+        # Portable pattern: two straight sum-filter queries, no
+        # dialect-specific CASE / IIF juggling.
+        db = self.transaction_service.db
+        try:
+            debit_sum = db.session.query(
+                sa_func.coalesce(sa_func.sum(Transactions.amount), 0)
+            ).filter(
+                Transactions.fileID == file_id,
+                Transactions.user == user_id,
+                Transactions.amount > 0,
+            ).scalar() or 0
+            credit_sum_signed = db.session.query(
+                sa_func.coalesce(sa_func.sum(Transactions.amount), 0)
+            ).filter(
+                Transactions.fileID == file_id,
+                Transactions.user == user_id,
+                Transactions.amount < 0,
+            ).scalar() or 0
+            # summary convention: credits as positive magnitude.
+            credit_sum = -float(credit_sum_signed or 0)
+            debit_sum = float(debit_sum or 0)
+        except Exception as e:
+            self.logger.warning(
+                f"ak-ifc file-reconciliation: could not aggregate "
+                f"extracted totals (file={file_id!r}): {e}. Skipping."
+            )
+            return
+
+        recon = check_hdfc_reconciliation_from_totals(
+            debit_sum, credit_sum, summary,
+        )
+
+        num_chunks = len(chunks) if chunks is not None else 0
+
+        if summary is None:
+            self.logger.info(
+                f"ak-ifc file-reconciliation: SKIPPED — HDFC savings "
+                f"summary not parseable from file {file_id!r} "
+                f"(num_chunks={num_chunks}). Extraction stands."
+            )
+            return
+
+        if not recon.diverged:
+            self.logger.info(
+                f"ak-ifc file-reconciliation: CLEAN — extracted totals "
+                f"within tolerance of PDF summary. "
+                f"file={file_id!r} num_chunks={num_chunks} "
+                f"debits: extracted={recon.extracted_debits} vs "
+                f"stated={recon.stated_debits}; "
+                f"credits: extracted={recon.extracted_credits} vs "
+                f"stated={recon.stated_credits}"
+            )
+            return
+
+        # DIVERGED — fallback.
+        self.logger.warning(
+            f"ak-ifc file-reconciliation: DIVERGED — masked extraction "
+            f"totals disagree with the PDF's savings summary at file "
+            f"level. file={file_id!r} bank={detected_bank} "
+            f"num_chunks={num_chunks} reason={recon.reason} "
+            f"checked={list(recon.checked_fields)}. "
+            f"Falling back to unfiltered extraction on ALL chunks "
+            f"(over-parse is recoverable via ak-8l5 dedup; under-parse "
+            f"is silent loss under Overseer's zero-loss constraint)."
+        )
+
+        # MINOR 1: mark the file for follow-up review.
+        try:
+            self.transaction_service.mark_reconciliation_fallback(
+                file_id, user_id=user_id,
+            )
+        except Exception as e:  # pragma: no cover — defensive
+            self.logger.warning(
+                f"ak-ifc file-reconciliation: mark_reconciliation_fallback "
+                f"threw: {e}. Continuing with re-run regardless."
+            )
+
+        # Re-run each chunk in no-mask mode. ak-8l5-v2 dedup at the
+        # storage layer handles the redundant inserts — existing rows
+        # collapse via primary hash; previously-missed savings rows
+        # land. The final DB state reflects the union of both passes.
+        for start, end in chunks:
+            self.logger.info(
+                f"ak-ifc file-reconciliation: re-running chunk "
+                f"{start}-{end} with force_no_mask=True"
+            )
+            try:
+                await self._run_text_chunk(
+                    text_mode_options, pdf_path, email, user_id, password,
+                    page_start=start, page_end=end,
+                    total_pages=total_pages,
+                    preset_file_id=file_id,
+                    force_no_mask=True,
+                )
+            except Exception as e:  # pragma: no cover — defensive
+                self.logger.error(
+                    f"ak-ifc file-reconciliation: no-mask re-run of "
+                    f"chunk {start}-{end} failed: {e}. Data partial; "
+                    f"file is tagged for manual review."
+                )
 
     # JSON schema for structured output in text mode.
     # ak-8l5: adds bank_reference_id + line_position per row.
@@ -1670,6 +1862,95 @@ class MailProcessorService:
         "required": ["transactions"],
     }
 
+    def _compute_hdfc_section_keep_mask(self, doc):
+        """ak-ifc: identify the SAVINGS section(s) in an HDFC combined
+        statement and return a per-file-line keep mask.
+
+        HDFC monthly PDFs are combined statements containing 5 sub-
+        accounts (savings, credit card, fixed deposit, mutual fund,
+        recurring deposit / PPF, etc.). The pre-ak-ifc extractor
+        treated the whole file as one savings statement, letting
+        other sub-accounts leak into the savings fileID:
+          - Apr 2026: +₹292k over-parse (non-savings debits treated
+            as savings)
+          - May 2026: -₹50k / -₹109k under-parse
+          - All 12 HDFC files affected
+
+        Fix: detect section headers ("Statement of Account for :
+        SAVINGS ...") in the raw text, mark only savings-section
+        lines as kept, blank the rest.
+
+        Returns a tuple (full_lines, keep_mask, page_line_ranges,
+        spans):
+          - full_lines: list[str] of every line in the doc, in
+            reading order, with a synthetic '\f<PAGE:N>' marker line
+            preceding each page's raw text
+          - keep_mask: list[bool] parallel to full_lines
+          - page_line_ranges: dict[page_num → (start_idx, end_idx)]
+            into full_lines
+          - spans: list[SectionSpan] from utils.statement_sections
+            for logging + auditing
+
+        Line count is PRESERVED per page (non-savings lines are
+        blanked, not deleted) so the ak-8l5 [Ln] file-level markers
+        the chunker adds later still point at stable positions.
+        """
+        from utils.statement_sections import (
+            detect_hdfc_sections,
+            SectionType,
+        )
+
+        # Build a doc-wide line array with synthetic per-page markers
+        # (a form-feed char + page tag) so we can map full-doc line
+        # indices back to their originating page for the chunk slice.
+        # Form feed is chosen because real bank text never contains
+        # it; safe as a sentinel.
+        full_lines: list[str] = []
+        page_line_ranges: dict[int, tuple[int, int]] = {}
+        for pn in range(1, doc.page_count + 1):
+            marker_idx = len(full_lines)
+            full_lines.append(f"\f<PAGE:{pn}>")
+            page_start_idx = len(full_lines)
+            raw_page = doc[pn - 1].get_text("text")
+            for line in raw_page.split("\n"):
+                full_lines.append(line)
+            page_end_idx = len(full_lines) - 1
+            page_line_ranges[pn] = (page_start_idx, page_end_idx)
+
+        full_text = "\n".join(full_lines)
+        spans = detect_hdfc_sections(full_text)
+
+        keep_mask = [False] * len(full_lines)
+        savings_span_count = 0
+        for span in spans:
+            if span.section == SectionType.SAVINGS:
+                savings_span_count += 1
+                # end_line is inclusive, but clamp defensively.
+                stop = min(span.end_line + 1, len(keep_mask))
+                for i in range(span.start_line, stop):
+                    keep_mask[i] = True
+
+        # Also keep the page-marker lines themselves — they're
+        # invisible to the LLM (we don't include them in the chunk
+        # text) but callers may want to walk the mask directly.
+        return full_lines, keep_mask, page_line_ranges, spans, savings_span_count
+
+    @staticmethod
+    def _extract_masked_page_text(full_lines, page_line_ranges, keep_mask, pn):
+        """Reconstruct one page's raw text with non-kept lines
+        blanked to empty strings.
+
+        Line count is preserved so the [Ln] file-level annotator that
+        runs downstream still produces stable positions across chunk
+        re-reads.
+        """
+        start, end = page_line_ranges[pn]
+        kept = [
+            full_lines[i] if keep_mask[i] else ""
+            for i in range(start, end + 1)
+        ]
+        return "\n".join(kept)
+
     @staticmethod
     def _strip_page_header(page_text):
         """Strip the repeated HDFC Smart Statement header from a page.
@@ -1701,11 +1982,20 @@ class MailProcessorService:
 
     async def _run_text_chunk(self, options, pdf_path, email, user_id, password,
                               page_start, page_end, total_pages,
-                              preset_file_id=None):
+                              preset_file_id=None, *, force_no_mask=False):
         """Process a text-mode PDF chunk using query() + structured output.
 
         No MCP tools — Claude returns structured JSON via output_format,
         we parse and insert directly.
+
+        ak-ifc v2 (`force_no_mask`): when the reconciliation backstop
+        detects a divergence between extracted savings totals and the
+        PDF's own summary, this method calls ITSELF a second time with
+        `force_no_mask=True` — the recursive call bypasses the section
+        filter entirely so no savings row can be silently lost. The
+        recursion is bounded (the recursed call has hdfc_mask=None so
+        it can't recurse further).
+
         Returns dict with insert stats: {"called": bool, "inserted": int, "duplicates": int}
         """
         import fitz as _fitz
@@ -1733,13 +2023,59 @@ class MailProcessorService:
             # across pages so re-reads collapse identically.
             line_ptr += raw_page_text.count("\n") + 1
 
+        # ak-ifc: for HDFC combined statements, precompute a per-file-
+        # line mask that keeps only the SAVINGS section. Non-savings
+        # lines are blanked to empty strings so line counts stay stable
+        # (ak-8l5 [Ln] markers depend on that).
+        # ak-ifc v2: the reconciliation backstop may re-enter this
+        # method with force_no_mask=True; honor that flag by skipping
+        # the mask computation entirely.
+        hdfc_mask = None
+        hdfc_spans_for_reconciliation = None
+        hdfc_full_text_for_reconciliation = None
+        if detected_bank == "HDFC_DEBIT" and not force_no_mask:
+            (full_lines, keep_mask, page_line_ranges, spans,
+             savings_span_count) = self._compute_hdfc_section_keep_mask(doc)
+            hdfc_mask = (full_lines, keep_mask, page_line_ranges)
+            # ak-ifc v2: keep the spans + full text around so the
+            # reconciliation backstop can parse the savings summary
+            # from the same view of the doc without re-scanning it.
+            hdfc_spans_for_reconciliation = spans
+            hdfc_full_text_for_reconciliation = "\n".join(full_lines)
+            from utils.statement_sections import summarize_sections
+            self.logger.info(
+                f"HDFC combined-statement section split: "
+                f"{summarize_sections(spans)}; "
+                f"savings_spans={savings_span_count} "
+                f"(pages {page_start}-{page_end} of {doc.page_count})"
+            )
+            if savings_span_count == 0:
+                self.logger.warning(
+                    f"HDFC statement has 0 detected SAVINGS sections — "
+                    f"either not a combined-statement layout OR the "
+                    f"header regex missed. Falling back to full-text "
+                    f"extraction (pre-ak-ifc behavior) to avoid dropping "
+                    f"all transactions."
+                )
+                hdfc_mask = None
+
         # Now pull the chunk's text, annotate each line with its
         # file-level line number so the LLM can echo the correct
         # position onto each extracted tx.
         page_texts = []
         for pn in range(page_start, page_end + 1):
             page = doc[pn - 1]
-            text = page.get_text("text")
+            if hdfc_mask is not None:
+                # Masked text: non-savings lines are blanked so the
+                # LLM only sees savings-section rows. Line-count is
+                # preserved so downstream annotations stay stable
+                # (ak-8l5 [Ln] markers below depend on this).
+                full_lines, keep_mask, page_line_ranges = hdfc_mask
+                text = self._extract_masked_page_text(
+                    full_lines, page_line_ranges, keep_mask, pn,
+                )
+            else:
+                text = page.get_text("text")
             clean_text = self._strip_page_header(text)
             annotated_lines = []
             local_line = 0
@@ -1795,6 +2131,16 @@ class MailProcessorService:
             f"unique reference number and must be extracted separately.\n"
             f"Extract from the FIRST transaction on each page to the LAST. Do not stop early.\n"
             f"ONLY extract transactions that appear in the text. Do NOT invent any.\n"
+            f"\n"
+            f"### ak-ifc combined-statement caveat (HDFC)\n"
+            f"HDFC monthly statements bundle 5 sub-accounts (savings, "
+            f"credit card, fixed deposit, mutual fund, recurring deposit). "
+            f"The extractor pre-filters the raw text to keep ONLY the "
+            f"SAVINGS section before you see it — non-savings lines are "
+            f"replaced with blanks. So the only rows in the text below "
+            f"are legitimate savings-account transactions; extract them "
+            f"all. If you see a 'Statement of Account for : <non-savings>' "
+            f"header slip through, ignore the section under it.\n"
         )
 
         # Health probe (hq-wisp-wzagg): mailProcessor SDK call diagnostic so
@@ -1866,6 +2212,18 @@ class MailProcessorService:
         self.logger.info(
             f"Chunk {page_start}-{page_end}: Claude returned {len(transactions)} transactions, inserting..."
         )
+
+        # ak-ifc v3: the per-chunk reconciliation gate that lived
+        # here in v2 was hoisted to file level in
+        # _run_all_chunks_async._run_hdfc_file_level_reconciliation.
+        # Reason: v2's `page_start==1 AND page_end==total_pages` gate
+        # meant only HDFC files ≤ pages_per_chunk (default 2) actually
+        # exercised the backstop — the combined statements that the
+        # whole ak-ifc effort targets are always multi-chunk, so the
+        # backstop never fired on them. See ak-ifc-v3 BOUNCE from
+        # akkountant/crew/akkountant_lead.
+        # We keep `force_no_mask` so the file-level orchestrator can
+        # re-invoke each chunk in a no-mask mode.
 
         # Insert directly via the existing tool executor logic
         insert_args = {

--- a/services/transactionsService.py
+++ b/services/transactionsService.py
@@ -469,6 +469,54 @@ class TransactionService(BaseService):
             else:
                 self.db.session.commit()
 
+    def mark_reconciliation_fallback(self, fileId, user_id=None):
+        """ak-ifc v3 MINOR 1: mark a fileDetails row as having
+        triggered the savings-summary reconciliation fallback.
+
+        The row is tagged so a follow-up sweep can flag the file for
+        manual review of the acknowledged non-savings over-parse
+        that unfiltered extraction introduces.
+
+        Swallows ORM errors defensively so the fallback re-run still
+        lands the data even if the column isn't present yet — infra
+        needs to ALTER TABLE fileDetails ADD COLUMN
+        reconciliation_fallback BOOLEAN NOT NULL DEFAULT 0 before
+        this becomes observable.
+        """
+        try:
+            query = self.db.session.query(FileDetails).filter_by(fileID=fileId)
+            if user_id:
+                query = query.filter(FileDetails.user == user_id)
+            row = query.first()
+            if not row:
+                self.logger.warning(
+                    f"ak-ifc reconciliation-fallback tag: no fileDetails "
+                    f"row for fileID={fileId!r}"
+                )
+                return False
+            setattr(row, "reconciliation_fallback", True)
+            if isinstance(self.db, dict):
+                with self.db.session() as session:
+                    session.commit()
+            else:
+                self.db.session.commit()
+            self.logger.info(
+                f"ak-ifc reconciliation-fallback tag: marked fileID="
+                f"{fileId!r} for follow-up manual review"
+            )
+            return True
+        except Exception as e:
+            self.logger.warning(
+                f"ak-ifc reconciliation-fallback tag: could not mark "
+                f"fileID={fileId!r}: {e}. Data lands regardless; run "
+                f"the ALTER TABLE migration to enable this tag."
+            )
+            try:
+                self.db.session.rollback()
+            except Exception:
+                pass
+            return False
+
     def fetchFileDetails(self, page: int, filters: dict, user_id: str = None, page_size: int = 100):
         query = self.db.session.query(FileDetails).filter(FileDetails.deleted == False)
 

--- a/test_statement_sections.py
+++ b/test_statement_sections.py
@@ -1,0 +1,714 @@
+"""ak-ifc regression tests for utils/statement_sections.py.
+
+Bug ak-ifc (dispatch hq-wisp-nnhr2e): HDFC monthly PDFs are COMBINED
+statements — savings + credit card + fixed deposit + mutual fund +
+recurring deposit stitched into one file. The pre-fix extractor
+treated the whole file as one savings statement, letting other
+sub-accounts leak into the savings fileID:
+
+  Apr-2026 file: +₹292k over-parse (non-savings debits landed in
+                 the savings section)
+  May-2026 file: -₹50k credit + -₹109k debit missed
+  All 12 HDFC files affected.
+
+These tests lock in the section-header detector so future HDFC
+statement-format tweaks (a new sub-account, changed header phrasing)
+fail loudly instead of silently regressing to the pre-fix leak.
+
+Pure-Python; no framework deps.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from utils.statement_sections import (
+    SectionType,
+    SectionSpan,
+    detect_hdfc_sections,
+    keep_only_sections,
+    summarize_sections,
+)
+
+
+# ── Section header pattern matching ─────────────────────────────────
+
+
+class TestSectionHeaderPatterns(unittest.TestCase):
+    """Every phrasing HDFC has ever emitted in real statements should
+    match the expected SectionType."""
+
+    def _classify(self, header_line):
+        spans = detect_hdfc_sections(header_line + "\n(some content)\n")
+        # Leading UNKNOWN prefix span is only added when the header
+        # doesn't start at line 0; here the header IS line 0, so no
+        # leading span exists — spans[0] is the section we want.
+        self.assertGreaterEqual(len(spans), 1)
+        return spans[0].section
+
+    def test_savings_canonical(self):
+        self.assertEqual(
+            self._classify("Statement of Account for : SAVINGS ACCOUNT 12345******9012"),
+            SectionType.SAVINGS,
+        )
+
+    def test_savings_terse(self):
+        self.assertEqual(
+            self._classify("Statement for : SAVINGS ACCOUNT"),
+            SectionType.SAVINGS,
+        )
+
+    def test_savings_all_caps(self):
+        self.assertEqual(
+            self._classify("STATEMENT OF ACCOUNT FOR : SAVINGS ACCOUNT"),
+            SectionType.SAVINGS,
+        )
+
+    def test_savings_lowercase(self):
+        self.assertEqual(
+            self._classify("statement of account for: savings account"),
+            SectionType.SAVINGS,
+        )
+
+    def test_current(self):
+        self.assertEqual(
+            self._classify("Statement of Account for : CURRENT ACCOUNT"),
+            SectionType.CURRENT,
+        )
+
+    def test_credit_card_two_words(self):
+        self.assertEqual(
+            self._classify("Statement of Account for : CREDIT CARD"),
+            SectionType.CREDIT_CARD,
+        )
+
+    def test_credit_card_one_word(self):
+        self.assertEqual(
+            self._classify("Statement of Account for : CREDITCARD ..."),
+            SectionType.CREDIT_CARD,
+        )
+
+    def test_fixed_deposit(self):
+        self.assertEqual(
+            self._classify("Statement of Account for : FIXED DEPOSIT"),
+            SectionType.FIXED_DEPOSIT,
+        )
+
+    def test_recurring_deposit_before_fixed(self):
+        """Ordering guard: RECURRING must be checked before FIXED
+        because 'FIXED DEPOSIT' would substring-match 'RECURRING
+        DEPOSIT' if we searched in the wrong order.
+        """
+        self.assertEqual(
+            self._classify("Statement of Account for : RECURRING DEPOSIT"),
+            SectionType.RECURRING_DEPOSIT,
+        )
+
+    def test_mutual_fund(self):
+        self.assertEqual(
+            self._classify("Statement of Account for : MUTUAL FUND"),
+            SectionType.MUTUAL_FUND,
+        )
+
+    def test_ppf(self):
+        self.assertEqual(
+            self._classify("Statement of Account for : PPF"),
+            SectionType.PPF,
+        )
+
+    def test_public_provident_alias(self):
+        self.assertEqual(
+            self._classify("Statement of Account for : PUBLIC PROVIDENT FUND"),
+            SectionType.PPF,
+        )
+
+    def test_unrelated_line_is_not_a_header(self):
+        """Random narration line must not trigger a section."""
+        spans = detect_hdfc_sections(
+            "Some txn narration mentioning savings account balance\n"
+            "amount 1234\n"
+        )
+        # No section header found → whole file falls back to a single
+        # UNKNOWN span (documented behavior in detect_hdfc_sections).
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0].section, SectionType.UNKNOWN)
+
+
+# ── Multi-section boundary logic ────────────────────────────────────
+
+
+class TestMultiSection(unittest.TestCase):
+    """Real combined statements have multiple section headers in
+    sequence. Boundaries must be correct so downstream filters keep
+    only the intended rows."""
+
+    def test_leading_unknown_span_before_first_header(self):
+        """Lines 0-3 (account holder details, address block) come
+        BEFORE any 'Statement of Account for :' header. Those get
+        their own UNKNOWN span at the start."""
+        text = (
+            "Vidish Rajkumar\n"
+            "12 Main Street\n"
+            "Bengaluru 560001\n"
+            "\n"
+            "Statement of Account for : SAVINGS ACCOUNT ****9012\n"
+            "DATE  NARRATION  AMOUNT\n"
+            "01/04  Rent 25000\n"
+        )
+        spans = detect_hdfc_sections(text)
+        self.assertEqual(spans[0].section, SectionType.UNKNOWN)
+        self.assertEqual(spans[0].start_line, 0)
+        # Header is on line 4 (0-indexed); UNKNOWN runs 0..3.
+        self.assertEqual(spans[0].end_line, 3)
+        self.assertEqual(spans[1].section, SectionType.SAVINGS)
+        self.assertEqual(spans[1].start_line, 4)
+
+    def test_five_section_hdfc_layout(self):
+        """Full-shape HDFC combined statement — 5 sections in
+        expected order (savings, cc, fd, mf, rd)."""
+        text = "\n".join([
+            "Vidish Rajkumar",
+            "Statement of Account for : SAVINGS ACCOUNT",  # line 1
+            "savings row 1",
+            "savings row 2",
+            "Statement of Account for : CREDIT CARD",       # line 4
+            "cc row 1",
+            "cc row 2",
+            "Statement of Account for : FIXED DEPOSIT",     # line 7
+            "fd row",
+            "Statement of Account for : MUTUAL FUND",       # line 9
+            "mf row",
+            "Statement of Account for : RECURRING DEPOSIT", # line 11
+            "rd row",
+        ])
+        spans = detect_hdfc_sections(text)
+        # Expect 6 spans: leading UNKNOWN + 5 sections.
+        section_types = [s.section for s in spans]
+        self.assertEqual(section_types, [
+            SectionType.UNKNOWN,
+            SectionType.SAVINGS,
+            SectionType.CREDIT_CARD,
+            SectionType.FIXED_DEPOSIT,
+            SectionType.MUTUAL_FUND,
+            SectionType.RECURRING_DEPOSIT,
+        ])
+
+    def test_section_end_is_inclusive_of_last_line(self):
+        """A section's end_line must point at the last line BELONGING
+        to that section, not the line where the next header starts."""
+        text = "\n".join([
+            "Statement of Account for : SAVINGS ACCOUNT",  # line 0
+            "row A",  # line 1
+            "row B",  # line 2
+            "Statement of Account for : CREDIT CARD",  # line 3
+            "cc row",  # line 4
+        ])
+        spans = detect_hdfc_sections(text)
+        # Filter to sections (skip any leading UNKNOWN — none here
+        # since first line IS a header).
+        savings = next(s for s in spans if s.section == SectionType.SAVINGS)
+        credit = next(s for s in spans if s.section == SectionType.CREDIT_CARD)
+        # Savings starts at header line 0, ends at line 2 (the last
+        # 'row B' before the next header).
+        self.assertEqual(savings.start_line, 0)
+        self.assertEqual(savings.end_line, 2)
+        # Credit starts at header line 3, ends at line 4 (EOF).
+        self.assertEqual(credit.start_line, 3)
+        self.assertEqual(credit.end_line, 4)
+
+    def test_multiple_savings_sections_stay_separate(self):
+        """HDFC statements sometimes have the savings section split
+        by a re-header on a new page. Each 'Statement for : SAVINGS'
+        creates its OWN span so accounting stays honest — we don't
+        want to coalesce them into one and drop content between."""
+        text = "\n".join([
+            "Statement of Account for : SAVINGS ACCOUNT ****9012",
+            "row A",
+            "Statement of Account for : SAVINGS ACCOUNT ****9012",
+            "row B",
+        ])
+        spans = detect_hdfc_sections(text)
+        savings_spans = [s for s in spans if s.section == SectionType.SAVINGS]
+        # Two savings spans (one per header line).
+        self.assertEqual(len(savings_spans), 2)
+
+
+# ── keep_only_sections filter ────────────────────────────────────────
+
+
+class TestKeepOnlySections(unittest.TestCase):
+    """The filter that strips non-savings lines from the raw text
+    before it's handed to the LLM."""
+
+    def test_savings_kept_others_blanked(self):
+        text = "\n".join([
+            "PROLOGUE",                                       # 0 UNKNOWN
+            "Statement of Account for : SAVINGS ACCOUNT",     # 1 SAVINGS start
+            "savings row 1",                                  # 2 SAVINGS
+            "Statement of Account for : CREDIT CARD",         # 3 CC start
+            "cc row 1",                                       # 4 CC
+        ])
+        filtered, spans = keep_only_sections(text, [SectionType.SAVINGS])
+        lines = filtered.split("\n")
+        # Non-savings lines are blanked but the array length stays
+        # identical so line-numbering downstream still lines up.
+        self.assertEqual(len(lines), 5)
+        self.assertEqual(lines[0], "")  # UNKNOWN prologue blanked
+        # Savings header + row both kept.
+        self.assertIn("SAVINGS ACCOUNT", lines[1])
+        self.assertEqual(lines[2], "savings row 1")
+        # CC header + row blanked.
+        self.assertEqual(lines[3], "")
+        self.assertEqual(lines[4], "")
+
+    def test_no_savings_section_returns_all_blanks(self):
+        """Statement with only credit-card content should filter to
+        an entirely blank text — nothing to extract."""
+        text = "\n".join([
+            "Statement of Account for : CREDIT CARD",
+            "cc row 1",
+            "cc row 2",
+        ])
+        filtered, _ = keep_only_sections(text, [SectionType.SAVINGS])
+        # All non-blank content stripped.
+        self.assertEqual(filtered.strip(), "")
+
+    def test_compact_mode_removes_blanks(self):
+        """Non-default compact mode removes stripped lines entirely.
+        Useful when the caller manages its own line numbering."""
+        text = "\n".join([
+            "PROLOGUE",
+            "Statement of Account for : SAVINGS ACCOUNT",
+            "savings row",
+            "Statement of Account for : CREDIT CARD",
+            "cc row",
+        ])
+        filtered, _ = keep_only_sections(
+            text, [SectionType.SAVINGS],
+            replace_stripped_with_placeholder=False,
+        )
+        self.assertIn("SAVINGS ACCOUNT", filtered)
+        self.assertIn("savings row", filtered)
+        self.assertNotIn("CREDIT CARD", filtered)
+        self.assertNotIn("cc row", filtered)
+        self.assertNotIn("PROLOGUE", filtered)
+
+    def test_multiple_types_kept(self):
+        """The keep-list is a set — multiple sections can be kept in
+        one pass. Useful if we ever wire in HDFC_REGALIA extraction
+        from the CREDIT_CARD section on the same file."""
+        text = "\n".join([
+            "Statement of Account for : SAVINGS ACCOUNT",
+            "savings row",
+            "Statement of Account for : CREDIT CARD",
+            "cc row",
+            "Statement of Account for : FIXED DEPOSIT",
+            "fd row",
+        ])
+        filtered, _ = keep_only_sections(
+            text,
+            [SectionType.SAVINGS, SectionType.CREDIT_CARD],
+        )
+        self.assertIn("savings row", filtered)
+        self.assertIn("cc row", filtered)
+        self.assertNotIn("fd row", filtered)
+
+
+# ── Backward compat: single-account statement ────────────────────────
+
+
+class TestSingleAccountFallback(unittest.TestCase):
+    """Pre-ak-ifc single-account HDFC statements (no combined-format
+    section headers) must still be handled correctly — the caller in
+    mailProcessorService falls back to full-text extraction when the
+    detector finds zero savings spans."""
+
+    def test_no_headers_gives_single_unknown_span(self):
+        """A single-account statement has no 'Statement of Account
+        for :' headers. Detector returns one UNKNOWN span covering
+        the whole file."""
+        text = "\n".join([
+            "some savings-style narration",
+            "01/04  Rent Payment  25000",
+            "02/04  Salary Credit  -50000",
+        ])
+        spans = detect_hdfc_sections(text)
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0].section, SectionType.UNKNOWN)
+        self.assertEqual(spans[0].start_line, 0)
+        self.assertEqual(spans[0].end_line, 2)
+
+    def test_single_account_filter_blanks_everything(self):
+        """With keep=[SAVINGS] and no SAVINGS section detected, the
+        filter returns all-blank. mailProcessorService's caller
+        detects this (savings_span_count == 0) and falls back to
+        unfiltered extraction so we don't drop the whole file."""
+        text = "01/04  Rent  25000\n02/04  Salary  -50000\n"
+        filtered, _ = keep_only_sections(text, [SectionType.SAVINGS])
+        self.assertEqual(filtered.strip(), "")
+
+
+# ── summarize_sections helper ────────────────────────────────────────
+
+
+class TestSummarize(unittest.TestCase):
+    def test_summary_format(self):
+        text = "\n".join([
+            "Statement of Account for : SAVINGS ACCOUNT",
+            "row A",
+            "Statement of Account for : CREDIT CARD",
+            "cc row",
+        ])
+        spans = detect_hdfc_sections(text)
+        summary = summarize_sections(spans)
+        self.assertIn("SAVINGS(0-1)", summary)
+        self.assertIn("CREDIT_CARD(2-3)", summary)
+
+
+# ── ak-ifc v2: SAVINGS-summary reconciliation ───────────────────────
+
+
+from utils.statement_sections import (
+    HdfcSavingsSummary,
+    ReconciliationResult,
+    check_hdfc_reconciliation_from_totals,
+    check_hdfc_savings_reconciliation,
+    parse_hdfc_savings_summary,
+)
+
+
+class TestParseSavingsSummary(unittest.TestCase):
+    """parse_hdfc_savings_summary: extracts opening/closing balance
+    and total debits/credits from raw HDFC text."""
+
+    def test_basic_totals_extracted(self):
+        text = "\n".join([
+            "Statement of Account for : SAVINGS ACCOUNT",
+            "Opening Balance : 12,345.67",
+            "Total Debits : 45,678.00",
+            "Total Credits : 33,333.33",
+            "Closing Balance : 100.00",
+        ])
+        summary = parse_hdfc_savings_summary(text)
+        self.assertIsNotNone(summary)
+        self.assertAlmostEqual(summary.opening_balance, 12345.67)
+        self.assertAlmostEqual(summary.closing_balance, 100.00)
+        self.assertAlmostEqual(summary.total_debits, 45678.00)
+        self.assertAlmostEqual(summary.total_credits, 33333.33)
+
+    def test_alternate_amount_of_wording(self):
+        """Some HDFC layouts say "Amount of Debits" instead of "Total
+        Debits". Both should parse."""
+        text = "\n".join([
+            "Statement of Account for : SAVINGS",
+            "Amount of Debits: 1,00,000.50",
+            "Amount of Credits: 2,50,000.00",
+        ])
+        summary = parse_hdfc_savings_summary(text)
+        self.assertIsNotNone(summary)
+        self.assertAlmostEqual(summary.total_debits, 100000.50)
+        self.assertAlmostEqual(summary.total_credits, 250000.00)
+
+    def test_currency_prefix_tolerated(self):
+        text = "\n".join([
+            "Statement of Account for : SAVINGS",
+            "Opening Balance ₹ 12,345.67",
+            "Closing Balance Rs. 100.00",
+        ])
+        summary = parse_hdfc_savings_summary(text)
+        self.assertIsNotNone(summary)
+        self.assertAlmostEqual(summary.opening_balance, 12345.67)
+        self.assertAlmostEqual(summary.closing_balance, 100.00)
+
+    def test_dr_cr_suffix_tolerated(self):
+        text = "\n".join([
+            "Statement of Account for : SAVINGS",
+            "Opening Balance 12,345.67 CR",
+            "Closing Balance 100.00 Cr",
+        ])
+        summary = parse_hdfc_savings_summary(text)
+        self.assertIsNotNone(summary)
+        self.assertAlmostEqual(summary.opening_balance, 12345.67)
+
+    def test_no_summary_returns_none(self):
+        text = "\n".join([
+            "Statement of Account for : SAVINGS",
+            "01/04  Rent Payment  25000",
+            "02/04  Salary  -50000",
+        ])
+        summary = parse_hdfc_savings_summary(text)
+        self.assertIsNone(summary)
+
+    def test_partial_summary_returns_populated(self):
+        """Only some fields present → we return a summary with those
+        set and the rest as None. The reconciler skips None fields."""
+        text = "\n".join([
+            "Statement of Account for : SAVINGS",
+            "Total Debits: 45,678.00",
+            # no credits, no opening/closing
+        ])
+        summary = parse_hdfc_savings_summary(text)
+        self.assertIsNotNone(summary)
+        self.assertAlmostEqual(summary.total_debits, 45678.00)
+        self.assertIsNone(summary.total_credits)
+
+    def test_debit_credit_counts(self):
+        text = "\n".join([
+            "Statement of Account for : SAVINGS",
+            "No. of Debits: 42",
+            "Number of Credits: 8",
+            "Total Debits: 45678.00",
+        ])
+        summary = parse_hdfc_savings_summary(text)
+        self.assertIsNotNone(summary)
+        self.assertEqual(summary.debit_count, 42)
+        self.assertEqual(summary.credit_count, 8)
+
+    def test_spans_scoping_ignores_other_sections(self):
+        """When `spans` is provided, we scan only the SAVINGS-section
+        lines — the credit-card section's own totals must NOT bleed
+        into the SAVINGS summary parse."""
+        text = "\n".join([
+            "Statement of Account for : SAVINGS ACCOUNT",  # line 0
+            "Total Debits: 45,000.00",                     # line 1
+            "Total Credits: 30,000.00",                    # line 2
+            "Statement of Account for : CREDIT CARD",      # line 3
+            "Total Debits: 999,999.99",                    # line 4 (must NOT be picked up)
+            "Total Credits: 111,111.11",                   # line 5
+        ])
+        spans = detect_hdfc_sections(text)
+        summary = parse_hdfc_savings_summary(text, spans=spans)
+        self.assertIsNotNone(summary)
+        # Must pick up the savings-section totals, NOT the CC totals.
+        self.assertAlmostEqual(summary.total_debits, 45000.00)
+        self.assertAlmostEqual(summary.total_credits, 30000.00)
+
+    def test_spans_scoping_no_savings_returns_none(self):
+        """If spans has no SAVINGS section, we return None (nothing
+        to reconcile against — a strict view over the caller's
+        section knowledge)."""
+        text = "\n".join([
+            "Statement of Account for : CREDIT CARD",
+            "Total Debits: 45,000.00",
+        ])
+        spans = detect_hdfc_sections(text)
+        summary = parse_hdfc_savings_summary(text, spans=spans)
+        self.assertIsNone(summary)
+
+
+class TestCheckReconciliation(unittest.TestCase):
+    """check_hdfc_savings_reconciliation compares extracted totals
+    against a HdfcSavingsSummary and flags divergence beyond tolerance."""
+
+    def test_within_tolerance_clean(self):
+        rows = [
+            {"amount": 100.00},  # debit
+            {"amount": 200.00},  # debit
+            {"amount": -50.00},  # credit
+        ]
+        summary = HdfcSavingsSummary(
+            total_debits=300.00, total_credits=50.00,
+        )
+        recon = check_hdfc_savings_reconciliation(rows, summary)
+        self.assertFalse(recon.diverged)
+        self.assertEqual(recon.reason, "within tolerance")
+        self.assertAlmostEqual(recon.extracted_debits, 300.0)
+        self.assertAlmostEqual(recon.extracted_credits, 50.0)
+
+    def test_debits_diverge_flags(self):
+        rows = [
+            {"amount": 100.00},   # debit
+            {"amount": 200.00},   # debit — extracted total = 300
+        ]
+        summary = HdfcSavingsSummary(
+            total_debits=350.00, total_credits=0.0,
+        )
+        recon = check_hdfc_savings_reconciliation(rows, summary)
+        self.assertTrue(recon.diverged)
+        self.assertIn("debits", recon.reason)
+        self.assertIn("300.00", recon.reason)
+        self.assertIn("350.00", recon.reason)
+
+    def test_credits_diverge_flags(self):
+        rows = [
+            {"amount": -100.00},  # credit magnitude 100
+        ]
+        summary = HdfcSavingsSummary(
+            total_debits=0.0, total_credits=200.00,  # extracted misses 100
+        )
+        recon = check_hdfc_savings_reconciliation(rows, summary)
+        self.assertTrue(recon.diverged)
+        self.assertIn("credits", recon.reason)
+
+    def test_1_rupee_rounding_ignored(self):
+        """Default tolerance is ₹1 to absorb HDFC's summary-line
+        rounding. Extracted 299.60 vs stated 300.00 → clean."""
+        rows = [
+            {"amount": 149.30},
+            {"amount": 150.30},   # sum 299.60
+        ]
+        summary = HdfcSavingsSummary(total_debits=300.00, total_credits=0.0)
+        recon = check_hdfc_savings_reconciliation(rows, summary)
+        self.assertFalse(recon.diverged)
+
+    def test_missing_summary_returns_skip(self):
+        """summary=None → check couldn't run; NOT a clean pass. The
+        caller inspects reason and logs the skip."""
+        rows = [{"amount": 100.0}]
+        recon = check_hdfc_savings_reconciliation(rows, None)
+        self.assertFalse(recon.diverged)
+        self.assertEqual(recon.reason, "no summary parsed")
+        # extracted sums still computed for the caller's log:
+        self.assertAlmostEqual(recon.extracted_debits, 100.0)
+
+    def test_summary_without_totals_returns_skip(self):
+        """Summary has only opening/closing balance, not total_debits
+        / total_credits → nothing to reconcile against."""
+        rows = [{"amount": 100.0}]
+        summary = HdfcSavingsSummary(
+            opening_balance=1000.0, closing_balance=900.0,
+        )
+        recon = check_hdfc_savings_reconciliation(rows, summary)
+        self.assertFalse(recon.diverged)
+        self.assertIn("no total_debits", recon.reason)
+
+    def test_partial_check_only_stated_fields(self):
+        """Summary has only total_debits (no total_credits). We check
+        debits and skip credits — no false-positive divergence on
+        the credit side."""
+        rows = [
+            {"amount": 100.0},
+            {"amount": -5000.0},  # credit that summary doesn't mention
+        ]
+        summary = HdfcSavingsSummary(total_debits=100.0)
+        recon = check_hdfc_savings_reconciliation(rows, summary)
+        self.assertFalse(recon.diverged)
+        self.assertEqual(recon.checked_fields, ("total_debits",))
+
+    def test_ignores_non_numeric_amount(self):
+        rows = [
+            {"amount": 100.0},
+            {"amount": "garbage"},   # skipped
+            {"amount": None},        # skipped
+        ]
+        summary = HdfcSavingsSummary(total_debits=100.0, total_credits=0.0)
+        recon = check_hdfc_savings_reconciliation(rows, summary)
+        self.assertFalse(recon.diverged)
+
+    def test_custom_tolerance(self):
+        rows = [{"amount": 100.0}]
+        summary = HdfcSavingsSummary(total_debits=110.0, total_credits=0.0)
+        # ₹5 tolerance → diverged (delta=10)
+        recon = check_hdfc_savings_reconciliation(rows, summary, tolerance=5.0)
+        self.assertTrue(recon.diverged)
+        # ₹20 tolerance → clean
+        recon = check_hdfc_savings_reconciliation(rows, summary, tolerance=20.0)
+        self.assertFalse(recon.diverged)
+
+
+class TestReconciliationEndToEnd(unittest.TestCase):
+    """End-to-end shape: raw text → parse summary → reconcile
+    extracted rows. Mirrors what mailProcessorService does per-file."""
+
+    def test_clean_run(self):
+        raw = "\n".join([
+            "Statement of Account for : SAVINGS ACCOUNT",
+            "Opening Balance : 12,345.67",
+            "Total Debits : 300.00",
+            "Total Credits : 50.00",
+            "Closing Balance : 12,095.67",
+        ])
+        spans = detect_hdfc_sections(raw)
+        summary = parse_hdfc_savings_summary(raw, spans=spans)
+        rows = [
+            {"amount": 100.00},
+            {"amount": 200.00},
+            {"amount": -50.00},
+        ]
+        recon = check_hdfc_savings_reconciliation(rows, summary)
+        self.assertFalse(recon.diverged)
+
+    def test_multi_chunk_clean_via_totals(self):
+        """ak-ifc v3 file-level baseline: three chunks each extracted
+        cleanly; aggregated totals match summary; no fallback."""
+        raw = "\n".join([
+            "Statement of Account for : SAVINGS ACCOUNT",
+            "Total Debits : 900.00",
+            "Total Credits : 300.00",
+        ])
+        summary = parse_hdfc_savings_summary(raw)
+        self.assertIsNotNone(summary)
+        # Simulate three chunks' contributions to the DB, aggregated.
+        chunk1_debits, chunk1_credits = 300.0, 100.0
+        chunk2_debits, chunk2_credits = 400.0, 150.0
+        chunk3_debits, chunk3_credits = 200.0, 50.0
+        agg_debits = chunk1_debits + chunk2_debits + chunk3_debits
+        agg_credits = chunk1_credits + chunk2_credits + chunk3_credits
+        recon = check_hdfc_reconciliation_from_totals(
+            agg_debits, agg_credits, summary,
+        )
+        self.assertFalse(recon.diverged)
+
+    def test_multi_chunk_chunk2_missed_via_totals(self):
+        """ak-ifc v3 file-level divergence: three chunks, chunk 2's
+        savings were silently under-parsed (partial header miss);
+        aggregated totals fall short → divergence detected → caller
+        would trigger force_no_mask re-run."""
+        raw = "\n".join([
+            "Statement of Account for : SAVINGS ACCOUNT",
+            "Total Debits : 900.00",
+            "Total Credits : 300.00",
+        ])
+        summary = parse_hdfc_savings_summary(raw)
+        # chunk 2 contributed nothing due to header miss:
+        agg_debits = 300.0 + 0.0 + 200.0        # 500 vs stated 900
+        agg_credits = 100.0 + 0.0 + 50.0        # 150 vs stated 300
+        recon = check_hdfc_reconciliation_from_totals(
+            agg_debits, agg_credits, summary,
+        )
+        self.assertTrue(recon.diverged)
+        # Both sides diverge:
+        self.assertIn("debits", recon.reason)
+        self.assertIn("credits", recon.reason)
+
+    def test_multi_chunk_no_summary_skips(self):
+        """ak-ifc v3 file-level: file has no summary → SKIP path;
+        the caller logs and proceeds without fallback (no false alarm
+        on statement layouts that omit the summary block)."""
+        summary = None
+        agg_debits, agg_credits = 500.0, 150.0
+        recon = check_hdfc_reconciliation_from_totals(
+            agg_debits, agg_credits, summary,
+        )
+        self.assertFalse(recon.diverged)
+        self.assertEqual(recon.reason, "no summary parsed")
+
+    def test_partial_header_miss_causes_divergence(self):
+        """Realistic scenario: statement had two SAVINGS re-headers.
+        Regex catches the first, misses the second, so ~half the
+        savings text is stripped from the LLM's view → extracted
+        totals fall short of stated totals → divergence flagged →
+        caller falls back to unfiltered extraction. (This test
+        simulates the extracted-side; the actual header-miss is
+        simulated by the extractor returning a partial row set.)"""
+        raw = "\n".join([
+            "Statement of Account for : SAVINGS ACCOUNT",
+            "Total Debits : 500.00",
+            "Total Credits : 100.00",
+        ])
+        summary = parse_hdfc_savings_summary(raw)
+        self.assertIsNotNone(summary)
+        # Simulate partial extraction — only 200 of 500 debits.
+        partial_rows = [{"amount": 200.00}, {"amount": -100.00}]
+        recon = check_hdfc_savings_reconciliation(partial_rows, summary)
+        self.assertTrue(recon.diverged)
+        self.assertIn("debits", recon.reason)
+
+
+if __name__ == "__main__":
+    print("ak-ifc statement-section detector regression tests")
+    print("=" * 60)
+    unittest.main(verbosity=2, exit=False)
+    print("=" * 60)

--- a/utils/statement_sections.py
+++ b/utils/statement_sections.py
@@ -1,0 +1,614 @@
+"""ak-ifc: HDFC combined-statement section detector + reconciliation.
+
+HDFC monthly PDFs are COMBINED statements: they contain multiple
+sub-accounts (savings, credit card, fixed deposit, mutual fund,
+recurring deposit / PPF, etc.) stitched together. The pre-ak-ifc
+extractor treated the whole file as one savings statement, so
+transactions from every other sub-account leaked into the savings
+fileID. Concrete damage per infra's ak-4b3 Lane C investigation:
+
+  Apr-2026: +₹292,000 EXTRA debits vs the savings-summary total
+            (non-savings debits treated as savings)
+  May-2026: -₹50,000 credit missed + -₹109,000 debit missed
+            (savings rows classified into the wrong section OR
+             dropped when the LLM ran out of context on non-savings
+             sections)
+  Affects: all 12 HDFC files, not just Apr / May.
+
+This module has two responsibilities:
+
+  1. Section-boundary detection so the extractor pre-filters raw
+     text to just the SAVINGS section before the LLM sees it.
+  2. Reconciliation backstop (ak-ifc v2 review, reviewer's proposal):
+     because a PARTIAL savings-header miss silently under-parses
+     (the pre-filter drops savings text between the missed header
+     and the next real header), we compare extracted savings totals
+     against the PDF's OWN stated savings summary. If they diverge
+     beyond a small tolerance, the caller falls back to unfiltered
+     extraction — preserving Overseer's zero-loss guarantee at the
+     cost of accepting the multi-account contamination we're
+     otherwise trying to filter (over-parse is recoverable via
+     dedup; under-parse is silent loss).
+
+Pure-Python, no framework deps.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable, Optional
+
+
+class SectionType(str, Enum):
+    """Enumerated account types HDFC combined statements can contain.
+
+    Values are stable string keys so they can be logged, persisted,
+    or compared without version drift. UNKNOWN is the fallback for
+    sections whose header didn't match any recognized pattern.
+    """
+    SAVINGS = "SAVINGS"
+    CURRENT = "CURRENT"
+    CREDIT_CARD = "CREDIT_CARD"
+    FIXED_DEPOSIT = "FIXED_DEPOSIT"
+    MUTUAL_FUND = "MUTUAL_FUND"
+    RECURRING_DEPOSIT = "RECURRING_DEPOSIT"
+    PPF = "PPF"
+    UNKNOWN = "UNKNOWN"
+
+
+# HDFC section headers observed in real statements. Ordered by
+# specificity so more-specific patterns match first (e.g. "RECURRING
+# DEPOSIT" before "DEPOSIT") — Python's regex alternation is
+# left-to-right, but we use a list of individual patterns so ordering
+# is explicit + auditable.
+#
+# We tolerate:
+#   - "Statement of Account for :"
+#   - "Statement for :"
+#   - "STATEMENT OF ACCOUNT FOR :" (all caps)
+#   - Trailing account number, mask, or extra whitespace
+#
+# The header is matched case-insensitively but the SectionType we
+# emit is normalized.
+_HDFC_SECTION_PATTERNS: list[tuple[SectionType, re.Pattern[str]]] = [
+    (
+        SectionType.SAVINGS,
+        re.compile(
+            r"statement\s+(?:of\s+account\s+)?for\s*:?\s*savings",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        SectionType.CURRENT,
+        re.compile(
+            r"statement\s+(?:of\s+account\s+)?for\s*:?\s*current",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        SectionType.CREDIT_CARD,
+        re.compile(
+            r"statement\s+(?:of\s+account\s+)?for\s*:?\s*credit\s*card",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        SectionType.RECURRING_DEPOSIT,
+        re.compile(
+            r"statement\s+(?:of\s+account\s+)?for\s*:?\s*recurring\s*deposit",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        SectionType.FIXED_DEPOSIT,
+        re.compile(
+            r"statement\s+(?:of\s+account\s+)?for\s*:?\s*fixed\s*deposit",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        SectionType.MUTUAL_FUND,
+        re.compile(
+            r"statement\s+(?:of\s+account\s+)?for\s*:?\s*mutual\s*fund",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        SectionType.PPF,
+        re.compile(
+            r"statement\s+(?:of\s+account\s+)?for\s*:?\s*(?:ppf|public\s+provident)",
+            re.IGNORECASE,
+        ),
+    ),
+]
+
+
+@dataclass(frozen=True)
+class SectionSpan:
+    """A contiguous slice of the raw statement text belonging to one
+    account section. Line indices are 0-indexed on the split-by-newline
+    array of the RAW file text (so callers can map to their own
+    line-numbering scheme via a simple `+1`).
+
+    end_line is inclusive of the last line in this section — i.e.
+    `raw_lines[start_line:end_line+1]` gives the section's text.
+    """
+    section: SectionType
+    start_line: int
+    end_line: int
+    header_line: int  # the line that carried the section-header pattern
+
+
+def detect_hdfc_sections(raw_text: str) -> list[SectionSpan]:
+    """Scan raw HDFC statement text and return one SectionSpan per
+    detected sub-account.
+
+    Rules:
+      - Every text file starts with an implicit UNKNOWN section from
+        line 0 up to the first header line (typically account-holder
+        details, address block, statement summary).
+      - Each header line begins a new SectionSpan whose type is
+        determined by the first pattern to match.
+      - Section runs until the next header line (or EOF).
+      - Adjacent same-type spans are NOT auto-merged. HDFC's savings
+        section often has a "Statement of Account for : SAVINGS
+        ACCOUNT ..." followed later by "Statement for : SAVINGS
+        ACCOUNT ..." (re-header on a new page); each header opens
+        its own span. Callers that only care about "is this a
+        savings line" (which is the typical use case) walk all
+        SectionType.SAVINGS spans without caring which is which —
+        `keep_only_sections` does exactly that.
+
+    Returns spans in order of appearance in the source text.
+    """
+    lines = raw_text.split("\n")
+    header_hits: list[tuple[int, SectionType]] = []
+    for line_idx, line in enumerate(lines):
+        # First-match wins — the pattern list is ordered specific-first.
+        for section_type, pattern in _HDFC_SECTION_PATTERNS:
+            if pattern.search(line):
+                header_hits.append((line_idx, section_type))
+                break
+
+    spans: list[SectionSpan] = []
+    if not header_hits:
+        # No section headers found → treat whole file as one UNKNOWN
+        # section. This matches the pre-ak-ifc behavior for
+        # single-account statements (they had no section headers and
+        # the LLM saw the whole thing).
+        if lines:
+            spans.append(
+                SectionSpan(
+                    section=SectionType.UNKNOWN,
+                    start_line=0,
+                    end_line=len(lines) - 1,
+                    header_line=-1,
+                ),
+            )
+        return spans
+
+    # Leading UNKNOWN span from line 0 to just before the first
+    # header. Callers usually strip this (account-holder / summary
+    # text isn't a transaction).
+    first_header_line = header_hits[0][0]
+    if first_header_line > 0:
+        spans.append(
+            SectionSpan(
+                section=SectionType.UNKNOWN,
+                start_line=0,
+                end_line=first_header_line - 1,
+                header_line=-1,
+            ),
+        )
+
+    # One span per header, running to (next_header - 1) or EOF.
+    for i, (header_line, section_type) in enumerate(header_hits):
+        if i + 1 < len(header_hits):
+            end_line = header_hits[i + 1][0] - 1
+        else:
+            end_line = len(lines) - 1
+        spans.append(
+            SectionSpan(
+                section=section_type,
+                start_line=header_line,
+                end_line=end_line,
+                header_line=header_line,
+            ),
+        )
+
+    return spans
+
+
+def keep_only_sections(
+    raw_text: str,
+    keep: Iterable[SectionType],
+    *,
+    replace_stripped_with_placeholder: bool = True,
+) -> tuple[str, list[SectionSpan]]:
+    """Return `raw_text` filtered to only the requested section types.
+
+    Line numbers of the kept lines are PRESERVED in the returned text
+    — stripped lines are either removed OR replaced with an empty
+    placeholder line (default: TRUE) so downstream line-number
+    annotations still point at the right file-level position.
+
+    The chunker in mailProcessorService adds `[Ln]` file-level line
+    markers that the LLM echoes back into `line_position` for the
+    ak-8l5 dedup engine. If we compressed the stripped sections out
+    entirely, those markers would be lopsided — some point at the
+    original file positions, some at the compressed. Placeholder-lines
+    keep the markers stable.
+
+    Returns (filtered_text, spans) so callers can log what got
+    stripped without re-scanning.
+    """
+    keep_set = frozenset(keep)
+    spans = detect_hdfc_sections(raw_text)
+    lines = raw_text.split("\n")
+
+    if replace_stripped_with_placeholder:
+        # Blank out lines that don't belong to a kept section, keeping
+        # the array length identical so line numbers stay stable.
+        keep_mask = [False] * len(lines)
+        for span in spans:
+            if span.section in keep_set:
+                for i in range(span.start_line, min(span.end_line + 1, len(lines))):
+                    keep_mask[i] = True
+        filtered_lines = [
+            lines[i] if keep_mask[i] else ""
+            for i in range(len(lines))
+        ]
+        return "\n".join(filtered_lines), spans
+
+    # Compact mode (rare — used when the caller re-numbers lines on
+    # its own downstream)
+    kept: list[str] = []
+    for span in spans:
+        if span.section in keep_set:
+            kept.extend(lines[span.start_line:span.end_line + 1])
+    return "\n".join(kept), spans
+
+
+def summarize_sections(spans: Iterable[SectionSpan]) -> str:
+    """Human-friendly one-line summary for logging.
+    Example: 'SAVINGS(120-450) CREDIT_CARD(451-800) UNKNOWN(0-119)'.
+    Callers use this to make section drift visible in prod logs.
+    """
+    parts = []
+    for s in spans:
+        parts.append(f"{s.section.value}({s.start_line}-{s.end_line})")
+    return " ".join(parts)
+
+
+# TODO(ak-ifc follow-up): BOI combined statements — Lead flagged that
+# BOI may have the same issue. When we get a real BOI combined-file
+# sample, add a _BOI_SECTION_PATTERNS + detect_boi_sections mirror.
+# The keep_only_sections helper is bank-agnostic (it takes the
+# `spans` output shape), so only the pattern list needs bank-specific
+# work.
+
+
+# ── ak-ifc v2: SAVINGS-summary reconciliation backstop ──────────────
+#
+# Reviewer flagged (MINOR 1, stealth-MAJOR under zero-loss constraint):
+# a PARTIAL savings-header miss produces a silent under-parse. Example:
+# a statement has two "SAVINGS ACCOUNT" re-headers, one on page 3 and
+# one on page 12. If the regex catches the first but the second is
+# slightly-off (extra whitespace, alternate wording), the range 12..N
+# gets stripped from the LLM's view even though it's really savings.
+# Result: transactions between page 12 and the next real header
+# vanish — no error, no warning, just missing rows.
+#
+# Backstop design: parse the PDF's OWN savings summary (opening bal,
+# closing bal, total debits, total credits) from the raw text; sum
+# what the extractor extracted; compare. If mismatched beyond a small
+# tolerance, the caller (mailProcessorService._run_text_chunk) falls
+# back to unfiltered extraction. Over-parse is recoverable via
+# ak-8l5 dedup; under-parse is silent loss.
+
+
+@dataclass(frozen=True)
+class HdfcSavingsSummary:
+    """The PDF's own stated totals for the SAVINGS section.
+
+    All fields are optional because different HDFC statement layouts
+    surface different subsets. The reconciler only compares fields
+    that are present on BOTH sides (extracted vs stated).
+
+    Positive convention:
+      - total_debits: sum of money OUT of the account (positive)
+      - total_credits: sum of money INTO the account (positive; kept
+        as a positive magnitude so the caller compares against
+        abs(sum(negatives)) from the extracted rows)
+      - opening_balance, closing_balance: signed as they appear in
+        the statement (CR/DR annotations already normalized out;
+        usually positive)
+    """
+    opening_balance: Optional[float] = None
+    closing_balance: Optional[float] = None
+    total_debits: Optional[float] = None
+    total_credits: Optional[float] = None
+    debit_count: Optional[int] = None
+    credit_count: Optional[int] = None
+
+
+# HDFC's savings-summary block appears at the head of the SAVINGS
+# section in various shapes across the layout revisions. We tolerate
+# common variants:
+#
+#   "Opening Balance : 12,345.67"
+#   "Opening Balance    12345.67"
+#   "OPENING BALANCE  ₹12,345.67 CR"
+#
+#   "Total Debits : 45,678.00" or "Amount of Debits" or "Debits Amt"
+#   "Total Credits : 33,333.33" or "Amount of Credits" or "Credits Amt"
+#
+#   "Closing Balance : 100.00"
+#
+# The regexes below are all case-insensitive and tolerant of ₹ / Rs /
+# INR prefixes plus DR/CR suffixes. Amount strings can contain commas
+# (Indian numbering — "1,00,000") and an optional decimal.
+_NUM_RE = r"(?:\d{1,3}(?:,\d{2,3})*|\d+)(?:\.\d+)?"
+_CURRENCY_PREFIX = r"(?:₹|Rs\.?|INR)?\s*"
+_DR_CR_SUFFIX = r"\s*(?:DR|CR|Dr|Cr)?"
+
+
+def _amount(match_str: str) -> Optional[float]:
+    """Parse an amount string like '1,23,456.78' into a float.
+    Returns None on garbage."""
+    if not match_str:
+        return None
+    stripped = match_str.replace(",", "").strip()
+    try:
+        return float(stripped)
+    except ValueError:
+        return None
+
+
+_HDFC_SUMMARY_PATTERNS = {
+    "opening_balance": re.compile(
+        r"opening\s*balance\s*[:\-]?\s*"
+        + _CURRENCY_PREFIX + r"(" + _NUM_RE + r")" + _DR_CR_SUFFIX,
+        re.IGNORECASE,
+    ),
+    "closing_balance": re.compile(
+        r"closing\s*balance\s*[:\-]?\s*"
+        + _CURRENCY_PREFIX + r"(" + _NUM_RE + r")" + _DR_CR_SUFFIX,
+        re.IGNORECASE,
+    ),
+    "total_debits": re.compile(
+        r"(?:total|amount\s*of|amt\s*of|amt)\s*debits?\s*[:\-]?\s*"
+        + _CURRENCY_PREFIX + r"(" + _NUM_RE + r")" + _DR_CR_SUFFIX,
+        re.IGNORECASE,
+    ),
+    "total_credits": re.compile(
+        r"(?:total|amount\s*of|amt\s*of|amt)\s*credits?\s*[:\-]?\s*"
+        + _CURRENCY_PREFIX + r"(" + _NUM_RE + r")" + _DR_CR_SUFFIX,
+        re.IGNORECASE,
+    ),
+    "debit_count": re.compile(
+        r"(?:no\.?\s*of|number\s*of|count\s*of)\s*debits?\s*[:\-]?\s*(\d+)",
+        re.IGNORECASE,
+    ),
+    "credit_count": re.compile(
+        r"(?:no\.?\s*of|number\s*of|count\s*of)\s*credits?\s*[:\-]?\s*(\d+)",
+        re.IGNORECASE,
+    ),
+}
+
+
+def parse_hdfc_savings_summary(
+    raw_text: str,
+    *,
+    spans: Optional[Iterable[SectionSpan]] = None,
+) -> Optional[HdfcSavingsSummary]:
+    """Extract the SAVINGS-section summary from raw statement text.
+
+    If `spans` is provided (typically from detect_hdfc_sections), we
+    scan ONLY the SAVINGS-section lines — this avoids false-positive
+    matches on other sections' summaries (e.g. the credit-card
+    section's "Total Debits" line). If `spans` is None we scan the
+    whole file, which is fine when the caller knows the file is
+    single-account or when they just want a best-effort read.
+
+    Returns HdfcSavingsSummary populated with whichever fields we
+    could recognize. Fields we couldn't parse are left as None so
+    the reconciler naturally skips them. Returns None if not even a
+    single field could be parsed (there's nothing to reconcile
+    against; caller must not fabricate a divergence).
+    """
+    lines = raw_text.split("\n")
+
+    # If spans were provided, extract only the SAVINGS-section lines.
+    if spans is not None:
+        savings_ranges = [
+            (s.start_line, min(s.end_line, len(lines) - 1))
+            for s in spans if s.section == SectionType.SAVINGS
+        ]
+        if not savings_ranges:
+            # No savings section detected — nothing to parse.
+            return None
+        scan_text = "\n".join(
+            lines[a] for lo, hi in savings_ranges for a in range(lo, hi + 1)
+        )
+    else:
+        scan_text = raw_text
+
+    fields = {}
+    for field_name, pattern in _HDFC_SUMMARY_PATTERNS.items():
+        m = pattern.search(scan_text)
+        if not m:
+            continue
+        raw = m.group(1)
+        if field_name in ("debit_count", "credit_count"):
+            try:
+                fields[field_name] = int(raw)
+            except ValueError:
+                continue
+        else:
+            amt = _amount(raw)
+            if amt is not None:
+                fields[field_name] = amt
+
+    if not fields:
+        return None
+
+    return HdfcSavingsSummary(**fields)
+
+
+@dataclass(frozen=True)
+class ReconciliationResult:
+    """Output of check_hdfc_savings_reconciliation.
+
+    - diverged: True iff the extracted totals disagree with the PDF's
+      stated summary beyond `tolerance`.
+    - reason: short human-readable summary; logged when diverged=True.
+    - checked_fields: list of field names we actually compared. Empty
+      when the summary was missing entirely (caller must not treat
+      that as "clean" — the check simply couldn't run).
+    - extracted_debits / extracted_credits: sums the reconciler
+      computed from the extracted rows, for the caller's log.
+    - stated_debits / stated_credits: the PDF's own totals, for the
+      caller's log.
+    """
+    diverged: bool
+    reason: str
+    checked_fields: tuple = ()
+    extracted_debits: Optional[float] = None
+    extracted_credits: Optional[float] = None
+    stated_debits: Optional[float] = None
+    stated_credits: Optional[float] = None
+
+
+def check_hdfc_reconciliation_from_totals(
+    extracted_debits: float,
+    extracted_credits: float,
+    summary: Optional[HdfcSavingsSummary],
+    *,
+    tolerance: float = 1.0,
+) -> ReconciliationResult:
+    """ak-ifc v3: totals-only variant. Same decision logic as
+    check_hdfc_savings_reconciliation, but takes pre-aggregated
+    debit / credit sums (from a DB `SELECT SUM(amount) WHERE
+    amount > 0 GROUP BY ...` shape) instead of iterating rows.
+
+    The file-level orchestrator in mailProcessorService uses this
+    directly so the reconciler doesn't need to be handed a fake
+    two-row list to represent the aggregated totals.
+    """
+    return check_hdfc_savings_reconciliation(
+        [{"amount": float(extracted_debits)},
+         {"amount": -float(extracted_credits)}],
+        summary,
+        tolerance=tolerance,
+    )
+
+
+def check_hdfc_savings_reconciliation(
+    extracted_rows: Iterable[dict],
+    summary: Optional[HdfcSavingsSummary],
+    *,
+    tolerance: float = 1.0,
+) -> ReconciliationResult:
+    """Reviewer's proposal: compare extracted savings totals against
+    the PDF's stated savings summary; return ReconciliationResult
+    with diverged=True iff we're outside `tolerance`.
+
+    `extracted_rows` is an iterable of dicts with (at minimum) an
+    `amount` field. Convention (matches the extractor's output):
+      - amount > 0 → debit (money out)
+      - amount < 0 → credit (money in)
+
+    `summary` is a HdfcSavingsSummary (usually from
+    parse_hdfc_savings_summary). If None, we return a
+    diverged=False result with reason="no summary parsed" so the
+    caller knows the check couldn't run (this is NOT a clean pass —
+    caller MUST log the skip so it's visible if summaries stop
+    parsing across all files at once).
+
+    `tolerance` is the max allowed |extracted - stated| in ₹. Default
+    ₹1 accommodates rounding at the summary line (some HDFC layouts
+    round the summary to the nearest rupee). Increase if the caller
+    encounters legit noise, but never past ~10% of the expected
+    magnitude (which would defeat the point).
+    """
+    debit_sum = 0.0
+    credit_sum = 0.0
+    for row in extracted_rows:
+        try:
+            amt = float(row.get("amount", 0))
+        except (TypeError, ValueError):
+            continue
+        if amt > 0:
+            debit_sum += amt
+        elif amt < 0:
+            credit_sum += -amt  # magnitude, matches summary convention
+
+    if summary is None:
+        return ReconciliationResult(
+            diverged=False,
+            reason="no summary parsed",
+            checked_fields=(),
+            extracted_debits=round(debit_sum, 2),
+            extracted_credits=round(credit_sum, 2),
+        )
+
+    checked = []
+    delta_msgs = []
+
+    if summary.total_debits is not None:
+        checked.append("total_debits")
+        delta = abs(debit_sum - summary.total_debits)
+        if delta > tolerance:
+            delta_msgs.append(
+                f"debits: extracted={debit_sum:.2f} vs "
+                f"stated={summary.total_debits:.2f} "
+                f"(delta={delta:.2f})"
+            )
+
+    if summary.total_credits is not None:
+        checked.append("total_credits")
+        delta = abs(credit_sum - summary.total_credits)
+        if delta > tolerance:
+            delta_msgs.append(
+                f"credits: extracted={credit_sum:.2f} vs "
+                f"stated={summary.total_credits:.2f} "
+                f"(delta={delta:.2f})"
+            )
+
+    if not checked:
+        # Summary was parsed but the specific fields we care about
+        # (total_debits / total_credits) weren't in it. Treat as
+        # "check unable to run" — same shape as summary=None.
+        return ReconciliationResult(
+            diverged=False,
+            reason="summary parsed but no total_debits / total_credits",
+            checked_fields=tuple(checked),
+            extracted_debits=round(debit_sum, 2),
+            extracted_credits=round(credit_sum, 2),
+            stated_debits=summary.total_debits,
+            stated_credits=summary.total_credits,
+        )
+
+    if delta_msgs:
+        return ReconciliationResult(
+            diverged=True,
+            reason="; ".join(delta_msgs),
+            checked_fields=tuple(checked),
+            extracted_debits=round(debit_sum, 2),
+            extracted_credits=round(credit_sum, 2),
+            stated_debits=summary.total_debits,
+            stated_credits=summary.total_credits,
+        )
+
+    return ReconciliationResult(
+        diverged=False,
+        reason="within tolerance",
+        checked_fields=tuple(checked),
+        extracted_debits=round(debit_sum, 2),
+        extracted_credits=round(credit_sum, 2),
+        stated_debits=summary.total_debits,
+        stated_credits=summary.total_credits,
+    )


### PR DESCRIPTION
HDFC parser multi-section + file-level reconciliation backstop. Adds fileDetails.reconciliation_fallback (ALTER TABLE run on prod first — Overseer-confirmed). Single squash, rebased on Personal 6d223cb, 86/86 tests, MAJOR resolved. co:false. Auto-deploys on merge onto migrated DB.