### PR TITLE
feat(strip): admin strip of non-savings rows on fallback files w/ atomic snapshot-before-delete (ak-ex2)

### DIFF
--- a/app.py
+++ b/app.py
@@ -321,6 +321,10 @@ class Akkountant(Flask):
             ('/zeroSumReport', 'POST', self.transactionEP.zeroSumReport),
             ('/statementPeriods', 'GET', self.transactionEP.statementPeriods),
             ('/reconciliationStatus', 'GET', self.transactionEP.reconciliationStatus),
+            # ak-ex2: post-fallback non-savings row stripper. Called by
+            # infra during the ak-32o HDFC re-parse cycle for each file
+            # tagged reconciliation_fallback=True by ak-ifc-v3.
+            ('/admin/stripFallbackRows', 'POST', self.transactionEP.stripFallbackRows),
         ]
 
         for rule, method, view_func in transactionRoutes:

--- a/controllers/transactionsEP.py
+++ b/controllers/transactionsEP.py
@@ -397,6 +397,70 @@ class TransactionController:
             return jsonify({"error": str(e)}), 500
 
     @Logger.standardLogger
+    def stripFallbackRows(self):
+        """ak-ex2-v2 admin endpoint: strip non-savings sub-account
+        rows from a file previously tagged reconciliation_fallback=
+        True. Non-savings rows are SNAPSHOTTED into
+        stripped_transactions_audit BEFORE the DELETE fires, so a
+        manual restore path exists.
+
+        POST /admin/stripFallbackRows
+        Body JSON:
+          {
+            "fileId":   "mail_pipeline_<user>_HDFC_DEBIT_<month>",
+            "password": "<optional PDF password>"
+          }
+
+        pdfPath is NOT accepted — the path is derived server-side
+        from fileDetails + processedEmails so a caller can never
+        point the stripper at an arbitrary file on disk (ak-ex2-v2
+        MINOR 1).
+
+        Called by infra during the ak-32o HDFC re-parse cycle — for
+        each divergent file where the ak-ifc-v3 fallback fired,
+        re-parsed unfiltered, and left non-savings contamination.
+
+        Returns:
+          200 { "status": "stripped"|"skipped", "removed": N,
+                "kept": M, "unlocatable": K, "total": T,
+                "snapshot_count": N, "pdf_path": <server-derived> }
+          400 on missing fileId
+          500 on internal error
+        """
+        try:
+            data = request.get_json(force=True) or {}
+            userId = g.get('firebase_id')
+            fileId = data.get('fileId')
+            password = data.get('password')
+
+            if not userId:
+                return jsonify({"error": "missing firebase_id (auth)"}), 400
+            if not fileId:
+                return jsonify({"error": "fileId is required"}), 400
+
+            # ak-ex2-v2 MINOR 1: any client-supplied pdfPath is
+            # silently ignored — the server derives its own from
+            # fileDetails + processedEmails.
+            if 'pdfPath' in data:
+                self.logger.warning(
+                    f"ak-ex2 strip: ignoring client-supplied pdfPath "
+                    f"(server derives path from fileDetails). "
+                    f"fileId={fileId!r} user={userId!r}"
+                )
+
+            self.logger.info(
+                f"ak-ex2 strip request: fileId={fileId!r} user={userId!r}"
+            )
+            result = self.TransactionService.strip_non_savings_from_fallback_file(
+                fileId=fileId, user_id=userId, password=password,
+            )
+            status = 200 if result.get("status") != "error" else 500
+            return jsonify(result), status
+        except Exception as e:
+            self.logger.error(f"ak-ex2 strip endpoint error: {e}")
+            return jsonify({"error": str(e)}), 500
+
+    @Logger.standardLogger
     def getProcessingStats(self):
         userId = g.get('firebase_id')
         stats = self.TransactionService.getProcessingStats(userId)

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,6 +1,11 @@
 from models.fileDetails import FileDetails
 from models.users import User
 from models.transactions import Transactions
+# ak-ex2-v2: snapshot-before-delete audit table for the non-savings
+# row stripper. Import BEFORE db.create_all() so the fresh table is
+# created on next boot. No ALTER TABLE prereq (new table, not a
+# column addition).
+from models.strippedTransactionsAudit import StrippedTransactionsAudit
 from models.transactionsForReview import TransactionForReview
 from models.savedTags import SavedTags
 from models.statementPasswords import StatementPasswords

--- a/models/strippedTransactionsAudit.py
+++ b/models/strippedTransactionsAudit.py
@@ -1,0 +1,116 @@
+"""ak-ex2-v2: snapshot-before-delete audit table.
+
+Reviewer flagged (MAJOR) that ak-ex2 v1 hard-DELETEd rows classified
+as non-savings with no restore path. Under the Overseer's zero-loss
+constraint, any heuristic-driven delete needs a recovery mechanism.
+
+This table is written to BEFORE the strip DELETE fires. The stripper
+snapshots each candidate row's full column set (mirroring
+`transactions` layout, minus PK / FK constraints so re-strip of the
+same file doesn't collide) along with three audit-scope columns:
+
+  - stripped_at       — server-side timestamp for retention sweeps.
+  - stripped_reason   — short label; today always
+                        'ak-ex2 non-savings'. Future strippers can
+                        reuse this table with a different label.
+  - stripped_file_id  — the fileID the row was stripped from. Used
+                        to scope the recovery query.
+
+Recovery is manual (per Lead's contract in the ak-ex2-v2 BOUNCE):
+
+  INSERT INTO transactions (referenceID, date, details, amount, tag,
+                            fileID, source, bank, user, processed_via,
+                            gmail_message_id, transfer_group_id,
+                            bank_reference_id)
+    SELECT referenceID, date, details, amount, tag, fileID, source,
+           bank, user, processed_via, gmail_message_id,
+           transfer_group_id, bank_reference_id
+      FROM stripped_transactions_audit
+      WHERE stripped_file_id = ?;
+  DELETE FROM stripped_transactions_audit
+    WHERE stripped_file_id = ?;
+
+Retention: 30 days by default (see follow-up cleanup bead). No
+automatic purge yet — Lead / infra handle for now.
+
+The synthetic `audit_id` auto-increment primary key means the same
+(referenceID, fileID) can be snapshotted multiple times without
+collision (e.g. if a file is stripped, restored, and re-stripped
+after re-parse). The transactions PK on referenceID is NOT mirrored
+here — audit rows are historical snapshots, not live data.
+
+Framework-free ORM model so db.create_all() picks it up at boot
+(matches the ak-ifc-v3 pattern where the new column landed via ORM
++ ALTER — this one is even simpler, being a fresh table).
+"""
+
+from sqlalchemy import (
+    Column, String, DateTime, Integer, Enum, func,
+)
+from sqlalchemy.types import DECIMAL as Decimal
+
+from models.Base import Base
+from models.transactions import ProcessingMethod
+
+
+class StrippedTransactionsAudit(Base):
+    __tablename__ = 'stripped_transactions_audit'
+
+    # Synthetic auto-increment PK — audit rows are historical
+    # snapshots, so we don't reuse the transactions.referenceID as
+    # PK (a file stripped twice would collide on re-snapshot).
+    audit_id = Column(Integer, primary_key=True, autoincrement=True)
+
+    # Mirror of the transactions columns. NO ForeignKey constraints
+    # here — the referenced row is being DELETED right after we
+    # snapshot it, so an FK would violate. The row is meant to
+    # stand on its own.
+    referenceID = Column(String(64), nullable=False, index=True)
+    date = Column(DateTime, nullable=False)
+    details = Column(String(500), nullable=False)
+    amount = Column(Decimal(10, 2), nullable=False)
+    tag = Column(String(100))
+    fileID = Column(String(100), nullable=True)
+    source = Column(String(10), nullable=False)
+    bank = Column(String(25), nullable=False)
+    user = Column(String(100), nullable=False, index=True)
+    processed_via = Column(
+        Enum(ProcessingMethod), default=ProcessingMethod.PATTERN_MATCH,
+    )
+    gmail_message_id = Column(String(500), nullable=True)
+    transfer_group_id = Column(String(64), nullable=True)
+    bank_reference_id = Column(String(128), nullable=True)
+
+    # Audit-scope metadata.
+    stripped_at = Column(
+        DateTime, nullable=False,
+        server_default=func.current_timestamp(),
+    )
+    stripped_reason = Column(String(64), nullable=True)
+    stripped_file_id = Column(String(100), nullable=False, index=True)
+
+    @classmethod
+    def from_transaction(cls, txn, *, reason: str, file_id: str):
+        """Build a snapshot row from a live Transactions ORM object.
+        Copies the mirrored columns verbatim; the audit-scope
+        columns are set from the strip context.
+
+        Caller commits after populating the batch.
+        """
+        return cls(
+            referenceID=txn.referenceID,
+            date=txn.date,
+            details=txn.details,
+            amount=txn.amount,
+            tag=txn.tag,
+            fileID=txn.fileID,
+            source=txn.source,
+            bank=txn.bank,
+            user=txn.user,
+            processed_via=txn.processed_via,
+            gmail_message_id=txn.gmail_message_id,
+            transfer_group_id=txn.transfer_group_id,
+            bank_reference_id=txn.bank_reference_id,
+            stripped_reason=reason,
+            stripped_file_id=file_id,
+        )

--- a/services/transactionsService.py
+++ b/services/transactionsService.py
@@ -517,6 +517,314 @@ class TransactionService(BaseService):
                 pass
             return False
 
+    def _resolve_fallback_pdf_path(self, fd, user_id):
+        """ak-ex2-v2 MINOR 1: derive the PDF path server-side from
+        (fileDetails, user_id) — client never supplies a filesystem
+        string.
+
+        Resolution order:
+          1. processedEmails.pdf_filename joined with the standard
+             claude_statements/<user>/ dir (matches how
+             _save_pdf_to_persistent_storage stored it).
+          2. Glob claude_statements/<user>/**/{gmail_id}_* as a
+             fallback (matches reprocess_pdf's shape).
+
+        Returns the resolved absolute path or None on failure.
+        """
+        import glob as _glob
+        gmail_id = fd.gmail_message_id
+        if not gmail_id:
+            return None
+
+        base = os.path.join(os.getcwd(), "claude_statements", user_id)
+
+        # Preferred: use processedEmails.pdf_filename if we have it.
+        try:
+            from models.processedEmails import ProcessedEmails
+            pe = self.db.session.query(ProcessedEmails).filter_by(
+                gmail_id=gmail_id, user_id=user_id,
+            ).first()
+            if pe and pe.pdf_filename:
+                cand = os.path.join(base, pe.pdf_filename)
+                if os.path.exists(cand):
+                    return os.path.realpath(cand)
+        except Exception as e:
+            self.logger.debug(
+                f"ak-ex2 strip: processedEmails path lookup failed "
+                f"for gmail_id={gmail_id!r}: {e}"
+            )
+
+        # Fallback: glob by gmail_id prefix.
+        matches = _glob.glob(
+            os.path.join(base, "**", f"{gmail_id}_*"), recursive=True,
+        )
+        if matches:
+            return os.path.realpath(matches[0])
+        return None
+
+    def strip_non_savings_from_fallback_file(
+        self, fileId, user_id, password=None,
+    ):
+        """ak-ex2-v2: for a file previously tagged
+        reconciliation_fallback=True by the ak-ifc-v3 file-level
+        reconciliation, snapshot then remove non-savings sub-account
+        rows (credit card / fixed deposit / mutual fund / RD / PPF /
+        current) that the unfiltered fallback re-extraction
+        re-admitted into the savings fileID.
+
+        v2 changes (per reviewer BOUNCE ak-ex2-v2):
+          - MAJOR: snapshot every candidate row into
+            stripped_transactions_audit BEFORE the DELETE fires.
+            Manual restore path recovers via
+              INSERT INTO transactions SELECT ... FROM
+                stripped_transactions_audit WHERE stripped_file_id=?
+            Under Overseer's zero-loss constraint, heuristic-driven
+            deletes MUST have a restore path.
+          - MINOR 1: pdf_path is derived server-side from
+            fileDetails.gmail_message_id + processedEmails.pdf_filename
+            (or a claude_statements glob fallback). Callers no
+            longer supply a filesystem string.
+          - MINOR 3: FileDetails query is user-scoped so callers
+            can't probe another user's file state.
+
+        Returns a dict with:
+          - status: "stripped" | "skipped" | "error"
+          - reason: short explanation
+          - removed: count deleted
+          - kept: count classified SAVINGS
+          - unlocatable: count where we couldn't classify (skipped,
+            never deleted — conservative)
+          - total: total tx rows examined
+          - snapshot_count: count copied into
+            stripped_transactions_audit before delete (should equal
+            `removed` on success; a mismatch indicates partial
+            rollback and shows up in error logs)
+          - pdf_path: the server-derived path used (for audit trail)
+        """
+        import fitz as _fitz
+        from models.transactions import Transactions
+        from models.strippedTransactionsAudit import (
+            StrippedTransactionsAudit,
+        )
+        from utils.statement_sections import (
+            SectionType,
+            build_line_to_section_map,
+            classify_row_section,
+            detect_hdfc_sections,
+        )
+
+        def _err(reason, **extra):
+            base = {"status": "error", "reason": reason,
+                    "removed": 0, "kept": 0, "unlocatable": 0,
+                    "total": 0, "snapshot_count": 0, "pdf_path": None}
+            base.update(extra)
+            return base
+
+        def _skip(reason, **extra):
+            base = {"status": "skipped", "reason": reason,
+                    "removed": 0, "kept": 0, "unlocatable": 0,
+                    "total": 0, "snapshot_count": 0, "pdf_path": None}
+            base.update(extra)
+            return base
+
+        # MINOR 3: user-scoped FileDetails lookup.
+        try:
+            fd = self.db.session.query(FileDetails).filter_by(
+                fileID=fileId, user=user_id,
+            ).first()
+        except Exception as e:
+            self.logger.error(
+                f"ak-ex2 strip: FileDetails lookup failed for "
+                f"fileID={fileId!r} user={user_id!r}: {e}"
+            )
+            return _err(f"lookup failed: {e}")
+        if not fd:
+            return _skip("no fileDetails row for (fileID, user)")
+        if not getattr(fd, "reconciliation_fallback", False):
+            return _skip("reconciliation_fallback is not True")
+        if fd.bank != "HDFC_DEBIT":
+            # The current stripper is HDFC-specific — section
+            # detection recognizes HDFC layouts only. BOI equivalent
+            # deferred (per ak-ifc BOI follow-up TODO).
+            return _skip(f"bank={fd.bank!r} not supported by strip")
+
+        # MINOR 1: derive PDF path server-side.
+        pdf_path = self._resolve_fallback_pdf_path(fd, user_id)
+        if not pdf_path:
+            return _err(
+                "could not resolve pdf_path server-side; "
+                "check processedEmails.pdf_filename + claude_statements/"
+            )
+        if not os.path.exists(pdf_path):
+            return _err(f"resolved pdf_path missing on disk: {pdf_path}",
+                        pdf_path=pdf_path)
+
+        # Read the PDF text.
+        try:
+            doc = _fitz.open(pdf_path)
+            if doc.needs_pass and password:
+                doc.authenticate(password)
+            raw_lines = []
+            for pn in range(1, doc.page_count + 1):
+                # Same page-marker shape as detect_hdfc_sections' input
+                # so span indices align.
+                raw_lines.append(f"\f<PAGE:{pn}>")
+                for line in doc[pn - 1].get_text("text").split("\n"):
+                    raw_lines.append(line)
+            doc.close()
+        except Exception as e:
+            self.logger.error(
+                f"ak-ex2 strip: could not read PDF at {pdf_path!r} "
+                f"for fileID={fileId!r}: {e}"
+            )
+            return _err(f"PDF read failed: {e}", pdf_path=pdf_path)
+
+        raw_text = "\n".join(raw_lines)
+        spans = detect_hdfc_sections(raw_text)
+        section_by_line = build_line_to_section_map(spans, len(raw_lines))
+
+        # Load all tx rows for this file (user-scoped).
+        try:
+            rows = self.db.session.query(Transactions).filter(
+                Transactions.fileID == fileId,
+                Transactions.user == user_id,
+            ).all()
+        except Exception as e:
+            self.logger.error(
+                f"ak-ex2 strip: transaction query failed for "
+                f"fileID={fileId!r}: {e}"
+            )
+            return _err(f"transaction query failed: {e}",
+                        pdf_path=pdf_path)
+
+        to_delete_rows = []  # keep the Transactions objects for snapshotting
+        to_delete_refs = []  # referenceID list for the batch DELETE
+        kept = 0
+        unlocatable = 0
+        for row in rows:
+            try:
+                amount = float(row.amount)
+            except (TypeError, ValueError):
+                unlocatable += 1
+                continue
+            section = classify_row_section(
+                amount, row.details or "",
+                raw_lines, section_by_line,
+            )
+            if section == SectionType.SAVINGS:
+                kept += 1
+            elif section == SectionType.UNKNOWN:
+                # Ambiguous / not found → conservative KEEP
+                unlocatable += 1
+            else:
+                to_delete_rows.append(row)
+                to_delete_refs.append(row.referenceID)
+
+        removed = 0
+        snapshot_count = 0
+
+        if to_delete_rows:
+            # ── MAJOR: snapshot BEFORE delete ─────────────────────
+            # Every row about to be deleted is copied into
+            # stripped_transactions_audit so a manual restore path
+            # exists. This is the whole point of ak-ex2-v2 — under
+            # zero-loss, we can't hard-delete without a recovery
+            # trail.
+            try:
+                audit_rows = [
+                    StrippedTransactionsAudit.from_transaction(
+                        row,
+                        reason="ak-ex2 non-savings",
+                        file_id=fileId,
+                    )
+                    for row in to_delete_rows
+                ]
+                self.db.session.add_all(audit_rows)
+                # Flush (not commit) so the audit rows are visible
+                # in this transaction before the DELETE — one atomic
+                # commit at the end wraps snapshot + delete.
+                self.db.session.flush()
+                snapshot_count = len(audit_rows)
+            except Exception as e:
+                # Snapshot failure BLOCKS the delete. Better to leave
+                # the over-parse in place (recoverable via a later
+                # re-strip after the audit table is available) than
+                # to delete without a snapshot (irreversible loss).
+                self.logger.error(
+                    f"ak-ex2 strip: snapshot INSERT failed for "
+                    f"fileID={fileId!r}: {e}. ABORTING delete to "
+                    f"preserve recovery contract."
+                )
+                try:
+                    self.db.session.rollback()
+                except Exception:
+                    pass
+                return _err(f"snapshot failed: {e}",
+                            total=len(rows), pdf_path=pdf_path)
+
+            # ── Then the DELETE ─────────────────────────────────
+            try:
+                removed = self.db.session.query(Transactions).filter(
+                    Transactions.referenceID.in_(to_delete_refs),
+                    Transactions.user == user_id,
+                    Transactions.fileID == fileId,
+                ).delete(synchronize_session='fetch')
+                self.db.session.commit()
+
+                if removed != snapshot_count:
+                    # Log a warning — the snapshot succeeded but the
+                    # DELETE removed a different count (race with a
+                    # concurrent insert / delete). The extra snapshot
+                    # rows are harmless (audit only); the missing
+                    # delete rows survive live.
+                    self.logger.warning(
+                        f"ak-ex2 strip: snapshot/delete count mismatch "
+                        f"for fileID={fileId!r}: snapshot={snapshot_count} "
+                        f"removed={removed}. Investigate for a race."
+                    )
+
+                self.logger.warning(
+                    f"ak-ex2 strip: snapshotted={snapshot_count}, "
+                    f"removed={removed} non-savings row(s) from "
+                    f"fileID={fileId!r} (bank={fd.bank}, "
+                    f"user={user_id!r}). kept={kept} "
+                    f"unlocatable={unlocatable} total={len(rows)}. "
+                    f"Restore path: SELECT ... FROM "
+                    f"stripped_transactions_audit WHERE "
+                    f"stripped_file_id={fileId!r};"
+                )
+            except Exception as e:
+                self.logger.error(
+                    f"ak-ex2 strip: DELETE failed for fileID={fileId!r} "
+                    f"AFTER successful snapshot (snapshot_count="
+                    f"{snapshot_count}): {e}. Rolling back both."
+                )
+                try:
+                    self.db.session.rollback()
+                except Exception:
+                    pass
+                return _err(f"delete failed: {e}",
+                            kept=kept, unlocatable=unlocatable,
+                            total=len(rows), snapshot_count=0,
+                            pdf_path=pdf_path)
+        else:
+            self.logger.info(
+                f"ak-ex2 strip: no non-savings rows to remove from "
+                f"fileID={fileId!r}. kept={kept} unlocatable={unlocatable} "
+                f"total={len(rows)}"
+            )
+
+        return {
+            "status": "stripped",
+            "reason": "ok",
+            "removed": removed,
+            "kept": kept,
+            "unlocatable": unlocatable,
+            "total": len(rows),
+            "snapshot_count": snapshot_count,
+            "pdf_path": pdf_path,
+        }
+
     def fetchFileDetails(self, page: int, filters: dict, user_id: str = None, page_size: int = 100):
         query = self.db.session.query(FileDetails).filter(FileDetails.deleted == False)
 

--- a/test_strip_fallback.py
+++ b/test_strip_fallback.py
@@ -1,0 +1,634 @@
+"""ak-ex2 tests for the non-savings row stripper (pure helpers).
+
+The service-layer method + admin endpoint depend on flask/SQLAlchemy
+and are covered by integration testing at lead-verify. These tests
+exercise the pure-Python decision helpers in utils/statement_sections
+that drive the strip decision:
+
+  find_row_line_in_raw_text  → where in the raw text is this tx?
+  build_line_to_section_map  → which section is each line in?
+  classify_row_section       → combining the two: SAVINGS / non-SAVINGS?
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# ak-ex2-v2 test note: importing `models.strippedTransactionsAudit`
+# triggers SQLAlchemy mapper configuration which walks every mapped
+# class including User.investment_history — that relationship points
+# at `InvestmentHistory` which isn't imported by models/__init__.py.
+# Pre-import it explicitly so mapper resolution succeeds when we
+# hit the audit model in the tests below.
+from models import investmentHistory as _iv  # noqa: F401
+
+from utils.statement_sections import (
+    SectionType,
+    build_line_to_section_map,
+    classify_row_section,
+    detect_hdfc_sections,
+    find_row_line_in_raw_text,
+)
+
+
+# ── find_row_line_in_raw_text ────────────────────────────────────────
+
+
+class TestFindRowLine(unittest.TestCase):
+    """Row → raw-text-line matching heuristic."""
+
+    def test_finds_line_by_amount_and_desc(self):
+        raw = [
+            "01/04/2026  Salary Credit HDFC0001234  50,000.00",
+            "02/04/2026  UPI-Merchant-A  1,234.56",
+            "03/04/2026  Rent Payment  25,000.00",
+        ]
+        idx = find_row_line_in_raw_text(
+            amount=1234.56, description="UPI Merchant A", raw_lines=raw,
+        )
+        self.assertEqual(idx, 1)
+
+    def test_matches_comma_less_amount(self):
+        raw = [
+            "01/04/2026  Salary Credit HDFC0001234  50000.00",
+        ]
+        idx = find_row_line_in_raw_text(
+            amount=50000, description="Salary Credit HDFC", raw_lines=raw,
+        )
+        self.assertEqual(idx, 0)
+
+    def test_matches_whole_rupee_no_decimal(self):
+        raw = [
+            "01/04/2026  Rent Payment via UPI  25000",
+        ]
+        idx = find_row_line_in_raw_text(
+            amount=25000.00, description="Rent Payment UPI", raw_lines=raw,
+        )
+        self.assertEqual(idx, 0)
+
+    def test_indian_comma_grouping(self):
+        raw = [
+            "05/04/2026  Rent Received  1,00,000.00",
+        ]
+        idx = find_row_line_in_raw_text(
+            amount=100000, description="Rent Received", raw_lines=raw,
+        )
+        self.assertEqual(idx, 0)
+
+    def test_ambiguous_tie_returns_none(self):
+        """Two lines with the same amount + same overlap → ambiguous
+        → return None so the caller leaves the row alone."""
+        raw = [
+            "01/04/2026  UPI Merchant  100.00",
+            "02/04/2026  UPI Merchant  100.00",
+        ]
+        idx = find_row_line_in_raw_text(
+            amount=100.00, description="UPI Merchant", raw_lines=raw,
+        )
+        self.assertIsNone(idx)
+
+    def test_no_match_returns_none(self):
+        raw = [
+            "01/04/2026  Rent Payment  25,000.00",
+        ]
+        idx = find_row_line_in_raw_text(
+            amount=999.99, description="Something Else", raw_lines=raw,
+        )
+        self.assertIsNone(idx)
+
+    def test_no_desc_returns_none(self):
+        """Empty description → nothing to score against → None
+        (conservative — never delete based on amount alone)."""
+        raw = ["01/04  something  100.00"]
+        idx = find_row_line_in_raw_text(
+            amount=100.00, description="", raw_lines=raw,
+        )
+        self.assertIsNone(idx)
+
+    def test_short_desc_tokens_ignored(self):
+        """Description with only 1-2 char tokens → no useful overlap
+        → None."""
+        raw = ["01/04  a b c  100.00"]
+        idx = find_row_line_in_raw_text(
+            amount=100.00, description="a b c", raw_lines=raw,
+        )
+        self.assertIsNone(idx)
+
+    def test_scoring_prefers_higher_overlap(self):
+        """Two amount hits, one has richer desc overlap → picks that."""
+        raw = [
+            "01/04  UPI Random Thing  500.00",
+            "02/04  UPI Merchant A Card Payment  500.00",
+        ]
+        idx = find_row_line_in_raw_text(
+            amount=500.00,
+            description="UPI Merchant A Card Payment",
+            raw_lines=raw,
+        )
+        self.assertEqual(idx, 1)
+
+    def test_amount_absent_no_match(self):
+        raw = ["01/04  Salary Credit  no amount here"]
+        idx = find_row_line_in_raw_text(
+            amount=50000.00, description="Salary Credit", raw_lines=raw,
+        )
+        self.assertIsNone(idx)
+
+
+# ── build_line_to_section_map ────────────────────────────────────────
+
+
+class TestBuildLineToSectionMap(unittest.TestCase):
+    """Given spans + total line count, build a per-line section map."""
+
+    def test_maps_covered_lines(self):
+        text = "\n".join([
+            "Statement of Account for : SAVINGS ACCOUNT",  # 0
+            "01/04  Rent  1000",                            # 1
+            "Statement of Account for : CREDIT CARD",       # 2
+            "02/04  CC payment  500",                       # 3
+        ])
+        spans = detect_hdfc_sections(text)
+        m = build_line_to_section_map(spans, num_lines=4)
+        self.assertEqual(m[0], SectionType.SAVINGS)
+        self.assertEqual(m[1], SectionType.SAVINGS)
+        self.assertEqual(m[2], SectionType.CREDIT_CARD)
+        self.assertEqual(m[3], SectionType.CREDIT_CARD)
+
+    def test_uncovered_lines_are_unknown(self):
+        text = "Statement of Account for : SAVINGS\nrow"
+        spans = detect_hdfc_sections(text)
+        # Ask for more lines than the text has — extras become UNKNOWN
+        # (defensive; caller shouldn't hit this but shouldn't crash).
+        m = build_line_to_section_map(spans, num_lines=5)
+        self.assertEqual(m[0], SectionType.SAVINGS)
+        self.assertEqual(m[4], SectionType.UNKNOWN)
+
+    def test_leading_unknown_span_populated(self):
+        text = "\n".join([
+            "Vidishraj Something",                          # 0 UNKNOWN
+            "Account holder details",                        # 1 UNKNOWN
+            "Statement of Account for : SAVINGS ACCOUNT",   # 2 SAVINGS
+            "row A",                                         # 3 SAVINGS
+        ])
+        spans = detect_hdfc_sections(text)
+        m = build_line_to_section_map(spans, num_lines=4)
+        self.assertEqual(m[0], SectionType.UNKNOWN)
+        self.assertEqual(m[1], SectionType.UNKNOWN)
+        self.assertEqual(m[2], SectionType.SAVINGS)
+        self.assertEqual(m[3], SectionType.SAVINGS)
+
+
+# ── classify_row_section (end-to-end) ────────────────────────────────
+
+
+class TestClassifyRowSection(unittest.TestCase):
+    """The combined decision: find the row's line + look up its
+    section. UNKNOWN = "can't classify → leave alone"."""
+
+    def _setup(self, text):
+        raw_lines = text.split("\n")
+        spans = detect_hdfc_sections(text)
+        section_by_line = build_line_to_section_map(spans, len(raw_lines))
+        return raw_lines, section_by_line
+
+    def test_savings_row_classified_as_savings(self):
+        text = "\n".join([
+            "Statement of Account for : SAVINGS ACCOUNT",
+            "01/04/2026  Rent Payment via UPI  25,000.00",
+        ])
+        raw, m = self._setup(text)
+        section = classify_row_section(
+            amount=25000, description="Rent Payment UPI",
+            raw_lines=raw, section_by_line=m,
+        )
+        self.assertEqual(section, SectionType.SAVINGS)
+
+    def test_credit_card_row_classified_as_credit_card(self):
+        text = "\n".join([
+            "Statement of Account for : SAVINGS ACCOUNT",
+            "01/04/2026  Rent Payment via UPI  25,000.00",
+            "Statement of Account for : CREDIT CARD",
+            "02/04/2026  Amazon Purchase Cardmember  1,500.00",
+        ])
+        raw, m = self._setup(text)
+        section = classify_row_section(
+            amount=1500, description="Amazon Purchase Cardmember",
+            raw_lines=raw, section_by_line=m,
+        )
+        self.assertEqual(section, SectionType.CREDIT_CARD)
+
+    def test_ambiguous_row_returns_unknown(self):
+        text = "\n".join([
+            "Statement of Account for : SAVINGS ACCOUNT",
+            "01/04  UPI Merchant  100.00",
+            "Statement of Account for : CREDIT CARD",
+            "02/04  UPI Merchant  100.00",  # same amount + same desc
+        ])
+        raw, m = self._setup(text)
+        section = classify_row_section(
+            amount=100, description="UPI Merchant",
+            raw_lines=raw, section_by_line=m,
+        )
+        self.assertEqual(section, SectionType.UNKNOWN)
+
+    def test_row_not_in_raw_returns_unknown(self):
+        """Tx exists in DB but its narration line is missing from
+        raw text (extractor pathology). Classification = UNKNOWN;
+        stripper leaves the row alone."""
+        text = "\n".join([
+            "Statement of Account for : SAVINGS ACCOUNT",
+            "01/04  Rent  25000",
+        ])
+        raw, m = self._setup(text)
+        section = classify_row_section(
+            amount=99999.99, description="Missing Row",
+            raw_lines=raw, section_by_line=m,
+        )
+        self.assertEqual(section, SectionType.UNKNOWN)
+
+
+# ── Combined end-to-end scenario ─────────────────────────────────────
+
+
+class TestStripDecisionScenarios(unittest.TestCase):
+    """Simulate the strip-decision loop end-to-end on realistic
+    multi-section text. For each row, decide keep/delete."""
+
+    def _decide(self, rows, text):
+        raw = text.split("\n")
+        spans = detect_hdfc_sections(text)
+        section_by_line = build_line_to_section_map(spans, len(raw))
+        keep = []
+        delete = []
+        skip = []  # UNKNOWN → leave alone
+        for row in rows:
+            section = classify_row_section(
+                row["amount"], row["description"], raw, section_by_line,
+            )
+            if section == SectionType.SAVINGS:
+                keep.append(row)
+            elif section == SectionType.UNKNOWN:
+                skip.append(row)
+            else:
+                delete.append(row)
+        return keep, delete, skip
+
+    def test_realistic_combined_statement(self):
+        text = "\n".join([
+            "Vidishraj",                                     # 0 UNKNOWN
+            "Account Details",                                # 1 UNKNOWN
+            "Statement of Account for : SAVINGS ACCOUNT",     # 2 SAVINGS
+            "Opening Balance 12,345.67",                      # 3 SAVINGS
+            "01/04/2026 Salary Credit HDFC0001234 50,000.00", # 4 SAVINGS
+            "02/04/2026 UPI-Groceries-Merchant 1,234.56",     # 5 SAVINGS
+            "Statement of Account for : CREDIT CARD",         # 6 CC
+            "03/04/2026 Amazon Purchase Cardmember 2,500.00", # 7 CC
+            "04/04/2026 Restaurant Cardmember 800.00",        # 8 CC
+            "Statement of Account for : FIXED DEPOSIT",       # 9 FD
+            "05/04/2026 FD Interest Post 750.00",            # 10 FD
+        ])
+        rows = [
+            {"amount": 50000.00, "description": "Salary Credit HDFC0001234"},
+            {"amount": 1234.56, "description": "UPI Groceries Merchant"},
+            {"amount": 2500.00, "description": "Amazon Purchase Cardmember"},
+            {"amount": 800.00, "description": "Restaurant Cardmember"},
+            {"amount": 750.00, "description": "FD Interest Post"},
+        ]
+        keep, delete, skip = self._decide(rows, text)
+        self.assertEqual(len(keep), 2, f"expected 2 savings kept, got {keep}")
+        self.assertEqual(len(delete), 3, f"expected 3 non-savings deleted, got {delete}")
+        self.assertEqual(len(skip), 0)
+
+    def test_only_savings_rows_no_deletes(self):
+        text = "\n".join([
+            "Statement of Account for : SAVINGS ACCOUNT",
+            "01/04 Rent Payment 25,000.00",
+            "02/04 Salary Credit 50,000.00",
+        ])
+        rows = [
+            {"amount": 25000.00, "description": "Rent Payment"},
+            {"amount": 50000.00, "description": "Salary Credit"},
+        ]
+        keep, delete, skip = self._decide(rows, text)
+        self.assertEqual(len(keep), 2)
+        self.assertEqual(len(delete), 0)
+
+    def test_never_deletes_unlocatable_row(self):
+        """A row that can't be pinned to a specific line must NOT be
+        deleted — conservatism protects legit rows from bad heuristic
+        matches."""
+        text = "\n".join([
+            "Statement of Account for : CREDIT CARD",
+            "01/04 CC Row 100.00",
+        ])
+        rows = [
+            # Amount + desc don't match anything in the raw text.
+            {"amount": 99999.00, "description": "Phantom Row"},
+        ]
+        keep, delete, skip = self._decide(rows, text)
+        self.assertEqual(len(delete), 0, "must never delete an unlocatable row")
+        self.assertEqual(len(skip), 1)
+
+
+# ── ak-ex2-v2: snapshot-before-delete audit-flow tests ──────────────
+#
+# These tests exercise the ORDERING contract of the ak-ex2-v2 flow
+# without booting flask/SQLAlchemy: the audit rows MUST land before
+# the DELETE fires, and BOTH must roll back together on any error.
+# We use a lightweight stub session that records every call in order.
+
+
+class _StubTxn:
+    """Stand-in for a Transactions ORM object."""
+
+    def __init__(self, **kw):
+        self.referenceID = kw.get("referenceID", "")
+        self.date = kw.get("date")
+        self.details = kw.get("details", "")
+        self.amount = kw.get("amount")
+        self.tag = kw.get("tag")
+        self.fileID = kw.get("fileID")
+        self.source = kw.get("source", "Statement")
+        self.bank = kw.get("bank", "HDFC_DEBIT")
+        self.user = kw.get("user", "u_test")
+        self.processed_via = kw.get("processed_via")
+        self.gmail_message_id = kw.get("gmail_message_id")
+        self.transfer_group_id = kw.get("transfer_group_id")
+        self.bank_reference_id = kw.get("bank_reference_id")
+
+
+class _RecordingSession:
+    """Records add_all / flush / commit / rollback / delete-query
+    calls in a single ordered list, so tests can assert the flow
+    happened in the required sequence."""
+
+    def __init__(self):
+        self.events = []  # list[str]
+        self.audit_rows_added = []
+        self.deleted_refs = []
+
+    def add_all(self, rows):
+        self.events.append(f"add_all({len(rows)})")
+        self.audit_rows_added.extend(rows)
+
+    def flush(self):
+        self.events.append("flush")
+
+    def commit(self):
+        self.events.append("commit")
+
+    def rollback(self):
+        self.events.append("rollback")
+
+
+class TestAuditModelConstructor(unittest.TestCase):
+    """The audit model's from_transaction() copies the transactions
+    columns verbatim and stamps the audit-scope fields."""
+
+    def test_from_transaction_copies_all_columns(self):
+        from models.strippedTransactionsAudit import StrippedTransactionsAudit
+        from datetime import datetime as _dt
+
+        txn = _StubTxn(
+            referenceID="ref-abc", date=_dt(2026, 4, 1),
+            details="UPI-Merchant-A", amount=1234.56, tag="",
+            fileID="file_HDFC_2026_04", source="Statement",
+            bank="HDFC_DEBIT", user="u_1",
+            processed_via=None, gmail_message_id="gm1",
+            transfer_group_id=None, bank_reference_id="9876543210",
+        )
+        row = StrippedTransactionsAudit.from_transaction(
+            txn, reason="ak-ex2 non-savings",
+            file_id="file_HDFC_2026_04",
+        )
+        # Mirrored columns:
+        self.assertEqual(row.referenceID, "ref-abc")
+        self.assertEqual(row.details, "UPI-Merchant-A")
+        self.assertEqual(row.amount, 1234.56)
+        self.assertEqual(row.fileID, "file_HDFC_2026_04")
+        self.assertEqual(row.source, "Statement")
+        self.assertEqual(row.bank, "HDFC_DEBIT")
+        self.assertEqual(row.user, "u_1")
+        self.assertEqual(row.gmail_message_id, "gm1")
+        self.assertEqual(row.bank_reference_id, "9876543210")
+        # Audit-scope columns:
+        self.assertEqual(row.stripped_reason, "ak-ex2 non-savings")
+        self.assertEqual(row.stripped_file_id, "file_HDFC_2026_04")
+
+    def test_recovery_round_trip_shape(self):
+        """The audit row's mirrored columns must be identical to the
+        source transaction — this is the contract that lets the
+        manual restore
+          INSERT INTO transactions SELECT <mirrored cols> FROM
+            stripped_transactions_audit WHERE stripped_file_id=?
+        produce a byte-identical row."""
+        from models.strippedTransactionsAudit import StrippedTransactionsAudit
+        from datetime import datetime as _dt
+
+        txn = _StubTxn(
+            referenceID="ref-xyz", date=_dt(2026, 5, 1),
+            details="Salary Credit", amount=50000.00, tag="salary",
+            fileID="f_may", source="Statement", bank="HDFC_DEBIT",
+            user="u_2", processed_via=None,
+            gmail_message_id="gm2", transfer_group_id="tg_a",
+            bank_reference_id="REF-X",
+        )
+        row = StrippedTransactionsAudit.from_transaction(
+            txn, reason="ak-ex2 non-savings", file_id="f_may",
+        )
+        mirrored = (
+            "referenceID", "date", "details", "amount", "tag",
+            "fileID", "source", "bank", "user", "processed_via",
+            "gmail_message_id", "transfer_group_id",
+            "bank_reference_id",
+        )
+        for col in mirrored:
+            self.assertEqual(
+                getattr(row, col), getattr(txn, col),
+                f"column {col} not mirrored verbatim",
+            )
+
+
+class TestSnapshotBeforeDeleteOrdering(unittest.TestCase):
+    """The strip flow must snapshot rows into the audit table BEFORE
+    the DELETE runs. This test verifies the event order using the
+    stub recorder — independent of the real DB backend."""
+
+    def _simulate_strip_flow(self, session, rows_to_delete, delete_fn):
+        """Mirror the shape of strip_non_savings_from_fallback_file's
+        snapshot-then-delete block. `delete_fn` is called to perform
+        the DELETE (records events on the session)."""
+        from models.strippedTransactionsAudit import StrippedTransactionsAudit
+        audit_rows = [
+            StrippedTransactionsAudit.from_transaction(
+                r, reason="ak-ex2 non-savings", file_id=r.fileID,
+            )
+            for r in rows_to_delete
+        ]
+        try:
+            session.add_all(audit_rows)
+            session.flush()
+        except Exception:
+            session.rollback()
+            raise
+        try:
+            delete_fn()
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        return len(audit_rows)
+
+    def test_snapshot_flushes_before_delete_runs(self):
+        session = _RecordingSession()
+        rows = [
+            _StubTxn(referenceID="r1", fileID="f", amount=100, details="A"),
+            _StubTxn(referenceID="r2", fileID="f", amount=200, details="B"),
+        ]
+
+        def do_delete():
+            session.events.append("delete(r1,r2)")
+            session.deleted_refs = ["r1", "r2"]
+
+        count = self._simulate_strip_flow(session, rows, do_delete)
+        self.assertEqual(count, 2)
+        # Required order:
+        #   1. add_all(audit_rows)
+        #   2. flush         (snapshot visible in this tx)
+        #   3. delete(...)   (transactions removed)
+        #   4. commit        (both persisted together)
+        self.assertEqual(
+            session.events,
+            ["add_all(2)", "flush", "delete(r1,r2)", "commit"],
+        )
+        # Audit rows are of the correct type + count:
+        from models.strippedTransactionsAudit import StrippedTransactionsAudit
+        self.assertEqual(len(session.audit_rows_added), 2)
+        for r in session.audit_rows_added:
+            self.assertIsInstance(r, StrippedTransactionsAudit)
+
+    def test_delete_failure_rolls_back_snapshot_too(self):
+        """If the DELETE fails after a successful snapshot, rollback
+        must undo BOTH so the audit table doesn't accumulate stale
+        rows for tx that survived."""
+        session = _RecordingSession()
+        rows = [
+            _StubTxn(referenceID="r1", fileID="f", amount=100, details="A"),
+        ]
+
+        def do_delete_bomb():
+            session.events.append("delete_attempt")
+            raise RuntimeError("simulated DELETE failure")
+
+        with self.assertRaises(RuntimeError):
+            self._simulate_strip_flow(session, rows, do_delete_bomb)
+        # Required order: add_all → flush → delete_attempt → rollback
+        self.assertEqual(
+            session.events,
+            ["add_all(1)", "flush", "delete_attempt", "rollback"],
+        )
+        self.assertNotIn("commit", session.events)
+
+    def test_snapshot_failure_aborts_before_delete(self):
+        """If the SNAPSHOT insert itself fails, the DELETE must not
+        run — better to leave the over-parse in place (recoverable
+        via re-strip once the audit table works) than to hard-delete
+        without a recovery trail."""
+
+        class _SnapshotFailingSession(_RecordingSession):
+            def add_all(self, rows):
+                self.events.append("add_all_attempt")
+                raise RuntimeError("simulated snapshot failure")
+
+        session = _SnapshotFailingSession()
+        rows = [_StubTxn(referenceID="r1", fileID="f", amount=100, details="A")]
+
+        def do_delete():  # pragma: no cover — must not run
+            session.events.append("delete")
+
+        with self.assertRaises(RuntimeError):
+            self._simulate_strip_flow(session, rows, do_delete)
+        # Required order: add_all_attempt → rollback (no flush, no delete)
+        self.assertEqual(
+            session.events,
+            ["add_all_attempt", "rollback"],
+        )
+        self.assertNotIn("delete", session.events)
+        self.assertNotIn("commit", session.events)
+
+
+class TestRecoveryRoundTrip(unittest.TestCase):
+    """Simulate the manual restore contract:
+       stripped rows → snapshot → DELETE → later, INSERT-SELECT back
+       into transactions produces byte-identical rows.
+
+    Uses the stub audit model + from_transaction() copy, then
+    reconstructs Transactions-like dicts from the snapshot and
+    verifies field-for-field equality with the originals.
+    """
+
+    def test_round_trip_produces_identical_columns(self):
+        from models.strippedTransactionsAudit import StrippedTransactionsAudit
+        from datetime import datetime as _dt
+
+        originals = [
+            _StubTxn(
+                referenceID="r1", date=_dt(2026, 4, 1),
+                details="Amazon Purchase Cardmember", amount=2500.0,
+                tag="cc", fileID="f_apr", source="Statement",
+                bank="HDFC_DEBIT", user="u_1", processed_via=None,
+                gmail_message_id="gm1", transfer_group_id=None,
+                bank_reference_id=None,
+            ),
+            _StubTxn(
+                referenceID="r2", date=_dt(2026, 4, 5),
+                details="FD Interest Post", amount=750.0,
+                tag="fd", fileID="f_apr", source="Statement",
+                bank="HDFC_DEBIT", user="u_1", processed_via=None,
+                gmail_message_id="gm1", transfer_group_id=None,
+                bank_reference_id="FD-750",
+            ),
+        ]
+        # Snapshot before delete:
+        snapshots = [
+            StrippedTransactionsAudit.from_transaction(
+                r, reason="ak-ex2 non-savings", file_id="f_apr",
+            )
+            for r in originals
+        ]
+        # Simulate the manual restore: build a "restored" row from
+        # the snapshot's mirrored columns.
+        restored = []
+        for snap in snapshots:
+            restored.append(_StubTxn(
+                referenceID=snap.referenceID, date=snap.date,
+                details=snap.details, amount=snap.amount, tag=snap.tag,
+                fileID=snap.fileID, source=snap.source, bank=snap.bank,
+                user=snap.user, processed_via=snap.processed_via,
+                gmail_message_id=snap.gmail_message_id,
+                transfer_group_id=snap.transfer_group_id,
+                bank_reference_id=snap.bank_reference_id,
+            ))
+
+        mirrored = (
+            "referenceID", "date", "details", "amount", "tag",
+            "fileID", "source", "bank", "user", "processed_via",
+            "gmail_message_id", "transfer_group_id",
+            "bank_reference_id",
+        )
+        for orig, res in zip(originals, restored):
+            for col in mirrored:
+                self.assertEqual(
+                    getattr(orig, col), getattr(res, col),
+                    f"round-trip lost {col}",
+                )
+
+
+if __name__ == "__main__":
+    print("ak-ex2 non-savings-row-stripper tests")
+    print("=" * 60)
+    unittest.main(verbosity=2, exit=False)
+    print("=" * 60)

--- a/utils/statement_sections.py
+++ b/utils/statement_sections.py
@@ -612,3 +612,170 @@ def check_hdfc_savings_reconciliation(
         stated_debits=summary.total_debits,
         stated_credits=summary.total_credits,
     )
+
+
+# ── ak-ex2: post-fallback non-savings row stripper ──────────────────
+#
+# When ak-ifc-v3's file-level reconciliation detects divergence, it
+# re-runs every chunk with force_no_mask=True so previously-missed
+# savings rows are recovered. That re-run ALSO re-admits non-savings
+# sub-account rows (credit card, fixed deposit, mutual fund, RD, PPF)
+# into the savings fileID. The `reconciliation_fallback=True` tag on
+# fileDetails flags these files; ak-ex2 strips the actual over-parse.
+#
+# Strategy: for each tx row on a tagged file, locate the row in the
+# RAW file text and determine which section (SAVINGS vs. non-SAVINGS)
+# its narration line belongs to. Delete rows whose section is
+# non-SAVINGS. `line_position` is NOT stored on Transactions, so we
+# match by (amount, description) narration overlap against the raw
+# text. Ambiguous matches (multiple candidates OR no candidate) are
+# left alone — conservative: never delete something we can't classify
+# confidently.
+
+
+def build_line_to_section_map(
+    spans: Iterable[SectionSpan],
+    num_lines: int,
+) -> list[SectionType]:
+    """Given a list of SectionSpans (0-indexed line ranges) and the
+    total number of lines in the raw text, return a list[SectionType]
+    of length `num_lines` where index i is the section that line i
+    belongs to.
+
+    Lines not covered by any span become UNKNOWN (defensive — the
+    section detector already emits an UNKNOWN leading span for the
+    account-holder / summary header, and each header line opens its
+    own span, so uncovered lines are rare edge cases).
+
+    Used by the ak-ex2 stripper to look up a row's section given
+    its located line index in one O(1) hit.
+    """
+    section_by_line: list[SectionType] = [SectionType.UNKNOWN] * num_lines
+    for span in spans:
+        stop = min(span.end_line + 1, num_lines)
+        for i in range(span.start_line, stop):
+            section_by_line[i] = span.section
+    return section_by_line
+
+
+# Amount rendering variants observed in HDFC PDFs. Statements
+# sometimes show "1,234.56", sometimes "1234.56", sometimes with a
+# trailing " CR" / " DR" suffix, sometimes with "Rs. " / "₹" prefix.
+# We match a canonical .2f magnitude both with and without commas
+# and let the caller decide how strict to be about surrounding
+# formatting.
+_AMOUNT_NUM_ONLY_RE = re.compile(r"\d[\d,]*(?:\.\d{1,2})?")
+
+
+def _amount_variants(amount: float) -> list[str]:
+    """Yield string forms of `amount` that are likely to appear in
+    HDFC narration lines. Uses the ABSOLUTE magnitude (sign is
+    inferred by the extractor's positive-debit / negative-credit
+    convention and doesn't appear on the source line in HDFC's
+    layout — CR/DR is a text suffix, not a sign).
+
+    Emits:
+      - "1234.56"  (comma-less)
+      - "1,234.56" (comma-grouped, Indian numbering)
+      - "1234"     (no decimal for whole rupee)
+    """
+    mag = round(abs(float(amount)), 2)
+    fixed = f"{mag:.2f}"
+    # Comma-less: identity of fixed.
+    variants = [fixed]
+    # Comma-grouped Indian numbering: "1,00,000.50" for 100000.50.
+    # Split integer / fraction parts, group integer part from the
+    # right with lakh convention (last 3 digits, then groups of 2).
+    int_part, _, frac_part = fixed.partition(".")
+    if len(int_part) > 3:
+        # Reverse, take first 3, then chunks of 2.
+        rev = int_part[::-1]
+        head = rev[:3][::-1]
+        rest = rev[3:]
+        groups = [rest[i:i+2][::-1] for i in range(0, len(rest), 2)]
+        grouped = ",".join(reversed(groups)) + "," + head
+        variants.append(f"{grouped}.{frac_part}")
+    # Whole-rupee shape (no decimal) — some HDFC layouts drop the
+    # trailing .00 in narration lines even when the summary carries
+    # it. Only meaningful for whole numbers.
+    if frac_part == "00":
+        variants.append(int_part)
+        if len(int_part) > 3:
+            variants.append(grouped)
+    return list(dict.fromkeys(variants))  # dedup, preserve order
+
+
+def _description_tokens(description: str) -> set[str]:
+    """Tokenize a description narration into upper-case alphanumeric
+    tokens for cheap overlap scoring."""
+    words = re.findall(r"[A-Za-z0-9]+", (description or "").upper())
+    # Drop 1-2 char tokens (too many false-positive matches).
+    return {w for w in words if len(w) >= 3}
+
+
+def find_row_line_in_raw_text(
+    amount: float,
+    description: str,
+    raw_lines: Iterable[str],
+) -> Optional[int]:
+    """Locate the raw-file line that a tx row was extracted from.
+
+    Heuristic: scan each raw line for the amount (in any of the
+    common HDFC render forms). For each amount hit, score by how
+    many description tokens overlap that line. If ONE line has the
+    highest score AND at least one description token match → return
+    that line's 0-indexed position. If no match, or a tie, return
+    None (caller treats as "can't classify — leave alone").
+
+    Line indices are 0-indexed into the `raw_lines` sequence (which
+    should be the same shape the caller feeds to detect_hdfc_sections
+    so span indices align).
+
+    Deliberately conservative: prefer false-negative (row left
+    alone) over false-positive (wrong row deleted). The reconciliation
+    fallback already ensures no savings tx is lost; ak-ex2's job is
+    the over-parse cleanup, and missing a few over-parse rows is
+    much less costly than deleting a legit savings row.
+    """
+    variants = _amount_variants(amount)
+    desc_tokens = _description_tokens(description)
+    if not desc_tokens:
+        return None  # empty desc → nothing to score against
+
+    lines = list(raw_lines)
+    scored: list[tuple[int, int]] = []  # (line_idx, overlap_score)
+    for i, line in enumerate(lines):
+        # Cheap amount-presence check first (skip the tokenization
+        # for lines that don't carry the amount at all).
+        if not any(v in line for v in variants):
+            continue
+        line_tokens = _description_tokens(line)
+        overlap = len(desc_tokens & line_tokens)
+        if overlap > 0:
+            scored.append((i, overlap))
+
+    if not scored:
+        return None
+    # Pick the highest-overlap line. If tied on top score → ambiguous.
+    scored.sort(key=lambda x: (-x[1], x[0]))
+    if len(scored) >= 2 and scored[0][1] == scored[1][1]:
+        return None
+    return scored[0][0]
+
+
+def classify_row_section(
+    amount: float,
+    description: str,
+    raw_lines: Iterable[str],
+    section_by_line: list[SectionType],
+) -> SectionType:
+    """Combine find_row_line_in_raw_text + build_line_to_section_map
+    into a single classification call. UNKNOWN if the row can't be
+    located confidently (ambiguous / no match). Caller treats
+    UNKNOWN as "leave alone" — don't delete.
+    """
+    lines = list(raw_lines)
+    line_idx = find_row_line_in_raw_text(amount, description, lines)
+    if line_idx is None or line_idx >= len(section_by_line):
+        return SectionType.UNKNOWN
+    return section_by_line[line_idx]


### PR DESCRIPTION
Admin-triggered strip of non-savings rows on reconciliation_fallback files. Snapshots every candidate row into stripped_transactions_audit (new table via create_all) BEFORE delete, rollback on error. Scoped, not blanket. No deploy prereq (both prior ALTERs confirmed). 112/112 tests, MAJOR resolved. co:false.