### PR TITLE
fix(extractor,pdf,sdk): ak-dby fallback-flag + ak-nyd per-file PDF passwords + ak-wty SDK backoff-retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,11 @@ CLAUDE.md
 /saved_emails/
 /uploads/
 /attachments/
+# ak-nyd v2: per-file PDF password store. Legacy default was
+# ./per_file_passwords.json (in-repo CWD) which is a landmine — the
+# gitignore entry blocks accidental commits even if operator ran an
+# old version of the CLI. New default lives outside the repo at
+# ~/.config/akkountant/per_file_passwords.json.
+per_file_passwords.json
+/per_file_passwords.json
+

--- a/manage_pdf_password.py
+++ b/manage_pdf_password.py
@@ -19,14 +19,24 @@ Usage:
   python manage_pdf_password.py remove --gmail-id 19c248db3a7b7d55
 
   # Use an explicit path (defaults to $AK_PER_FILE_PASSWORDS_PATH or
-  # ./per_file_passwords.json):
+  # ~/.config/akkountant/per_file_passwords.json — ak-nyd v2):
   python manage_pdf_password.py --path /etc/akkountant/pw.json list
 
 MailProcessor's reprocess_pdf reads this store before falling back to
 _try_personal_info_passwords. See utils/per_file_passwords.py for
-lookup semantics + security notes (chmod 600 the file; treat as
-short-lived recovery scaffolding; a proper encrypted store lands
-later under ak-2ln).
+lookup semantics + security notes.
+
+ak-nyd v2 security hardening (per reviewer BOUNCE):
+  - Default path is now ~/.config/akkountant/per_file_passwords.json
+    (OUTSIDE the source tree — v1 defaulted to CWD which risked
+    accidental git commits).
+  - The store file is written 0o600 (owner rw only) after every
+    write. Parent dir is 0o700 when we create it.
+  - Backend .gitignore blocks per_file_passwords.json at any depth
+    so an operator running an old (pre-v2) CLI can't accidentally
+    commit the file.
+  - Passwords still plaintext on disk — proper encrypted store lands
+    under ak-2ln umbrella.
 
 dispatched_by: akkountant/crew/akkountant_lead (hq-wisp-6n526p)
 bead: ak-nyd

--- a/manage_pdf_password.py
+++ b/manage_pdf_password.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""ak-nyd: CLI to manage per-file PDF password overrides.
+
+Usage:
+
+  # Add or update a password for a specific fileID or gmail_id:
+  python manage_pdf_password.py add \
+      --gmail-id 19c248db3a7b7d55 --password 'S3cret!'
+  python manage_pdf_password.py add \
+      --file-id mail_pipeline_uxxx_HDFC_DEBIT_2026_01 --password 'S3cret!'
+
+  # Look up an entry:
+  python manage_pdf_password.py get --gmail-id 19c248db3a7b7d55
+
+  # List all entries (values ELIDED — shows keys only):
+  python manage_pdf_password.py list
+
+  # Remove:
+  python manage_pdf_password.py remove --gmail-id 19c248db3a7b7d55
+
+  # Use an explicit path (defaults to $AK_PER_FILE_PASSWORDS_PATH or
+  # ./per_file_passwords.json):
+  python manage_pdf_password.py --path /etc/akkountant/pw.json list
+
+MailProcessor's reprocess_pdf reads this store before falling back to
+_try_personal_info_passwords. See utils/per_file_passwords.py for
+lookup semantics + security notes (chmod 600 the file; treat as
+short-lived recovery scaffolding; a proper encrypted store lands
+later under ak-2ln).
+
+dispatched_by: akkountant/crew/akkountant_lead (hq-wisp-6n526p)
+bead: ak-nyd
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from utils.per_file_passwords import (
+    add_password,
+    list_entries,
+    lookup_password,
+    remove_password,
+)
+
+
+def _cmd_add(args):
+    if not args.gmail_id and not args.file_id:
+        raise SystemExit("add: --gmail-id or --file-id required")
+    if not args.password:
+        raise SystemExit("add: --password required")
+    add_password(
+        args.password,
+        gmail_id=args.gmail_id, file_id=args.file_id,
+        path=args.path,
+    )
+    print(
+        f"[ADDED] gmail_id={args.gmail_id!r} file_id={args.file_id!r} "
+        f"(value elided)"
+    )
+
+
+def _cmd_get(args):
+    got = lookup_password(
+        gmail_id=args.gmail_id, file_id=args.file_id, path=args.path,
+    )
+    if got is None:
+        print("[MISS] no entry")
+        sys.exit(1)
+    if args.show_value:
+        print(f"[HIT] {got}")
+    else:
+        print(f"[HIT] gmail_id={args.gmail_id!r} file_id={args.file_id!r} "
+              f"(value elided; pass --show-value to reveal)")
+
+
+def _cmd_list(args):
+    entries = list_entries(path=args.path)
+    if not entries:
+        print("[EMPTY] no per-file password entries configured")
+        return
+    print(f"[LIST] {len(entries)} entrie(s):")
+    for k in sorted(entries):
+        if args.show_values:
+            print(f"  {k} = {entries[k]}")
+        else:
+            print(f"  {k}   (value elided)")
+
+
+def _cmd_remove(args):
+    ok = remove_password(
+        gmail_id=args.gmail_id, file_id=args.file_id, path=args.path,
+    )
+    if ok:
+        print(f"[REMOVED] gmail_id={args.gmail_id!r} file_id={args.file_id!r}")
+    else:
+        print(f"[MISS] nothing to remove")
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="ak-nyd per-file PDF password store CLI."
+    )
+    parser.add_argument("--path", default=None,
+                        help="Explicit JSON path (default: "
+                             "$AK_PER_FILE_PASSWORDS_PATH or "
+                             "./per_file_passwords.json)")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_add = sub.add_parser("add", help="Add/update a password entry")
+    p_add.add_argument("--gmail-id", default=None)
+    p_add.add_argument("--file-id", default=None)
+    p_add.add_argument("--password", required=True)
+    p_add.set_defaults(func=_cmd_add)
+
+    p_get = sub.add_parser("get", help="Look up a password entry")
+    p_get.add_argument("--gmail-id", default=None)
+    p_get.add_argument("--file-id", default=None)
+    p_get.add_argument("--show-value", action="store_true",
+                       help="Print the password (default: elided)")
+    p_get.set_defaults(func=_cmd_get)
+
+    p_list = sub.add_parser("list", help="List all entries")
+    p_list.add_argument("--show-values", action="store_true",
+                        help="Print passwords (default: keys only)")
+    p_list.set_defaults(func=_cmd_list)
+
+    p_remove = sub.add_parser("remove", help="Remove an entry")
+    p_remove.add_argument("--gmail-id", default=None)
+    p_remove.add_argument("--file-id", default=None)
+    p_remove.set_defaults(func=_cmd_remove)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mailProcessorService.py
+++ b/services/mailProcessorService.py
@@ -2058,30 +2058,40 @@ class MailProcessorService:
                     f"all transactions."
                 )
                 hdfc_mask = None
-                # ak-dby: when the detector misses (regex doesn't
-                # match any SAVINGS header — the exact pathology of
-                # the 2026 Vidish_Raj_ layout), the full-text
-                # fallback re-admits non-savings sub-account rows
-                # into the savings fileID. Mark the file so the
-                # /admin/stripFallbackRows endpoint (ak-ex2) picks it
-                # up on the next re-parse sweep. Same pattern as the
-                # ak-ifc-v3 file-level reconciliation fallback path,
-                # different trigger.
+                # ak-dby v2 (reviewer BOUNCE hq-wisp-*): the flag is
+                # only appropriate when the detector saw a
+                # combined-statement shape but MISSED the savings
+                # header specifically — i.e. non-savings sub-accounts
+                # WERE detected. A pure single-account statement (no
+                # section headers at all) also produces
+                # savings_spans==0 but shouldn't be flagged, because
+                # there's no non-savings contamination for the strip
+                # endpoint to clean up.
                 #
-                # Only mark when we have a preset_file_id — if the
-                # extractor is running against an ad-hoc PDF path
-                # (rare, non-pipeline), there's no fileDetails row
-                # to tag.
-                if preset_file_id:
+                # Compute non_savings_span_count from the same spans
+                # the mask computation returned.
+                from utils.statement_sections import SectionType
+                non_savings_span_count = sum(
+                    1 for s in spans
+                    if s.section not in (
+                        SectionType.SAVINGS,
+                        SectionType.UNKNOWN,
+                    )
+                )
+                if preset_file_id and non_savings_span_count >= 1:
                     try:
                         self.transaction_service.mark_reconciliation_fallback(
                             preset_file_id, user_id=user_id,
                         )
                         self.logger.info(
                             f"ak-dby: tagged fileID={preset_file_id!r} "
-                            f"reconciliation_fallback=True (savings_spans=0 "
-                            f"detector miss) so /admin/stripFallbackRows "
-                            f"can clean up leaked non-savings tx."
+                            f"reconciliation_fallback=True "
+                            f"(savings_spans=0 AND "
+                            f"non_savings_spans={non_savings_span_count} — "
+                            f"combined-statement layout whose savings "
+                            f"header regex missed) so "
+                            f"/admin/stripFallbackRows can clean up "
+                            f"leaked non-savings tx."
                         )
                     except Exception as e:  # pragma: no cover — defensive
                         self.logger.warning(
@@ -2090,6 +2100,18 @@ class MailProcessorService:
                             f"lands regardless; strip endpoint won't fire "
                             f"until the file is tagged manually."
                         )
+                else:
+                    # savings_spans=0 AND non_savings_spans=0 →
+                    # pure single-account statement (or full-doc
+                    # UNKNOWN). No contamination possible; nothing
+                    # to strip. Skip the tag.
+                    self.logger.info(
+                        f"ak-dby: NOT tagging fileID={preset_file_id!r} "
+                        f"(savings_spans=0, non_savings_spans="
+                        f"{non_savings_span_count}) — likely a "
+                        f"pure single-account statement with no "
+                        f"combined-layout contamination."
+                    )
 
         # Now pull the chunk's text, annotate each line with its
         # file-level line number so the LLM can echo the correct

--- a/services/mailProcessorService.py
+++ b/services/mailProcessorService.py
@@ -2232,24 +2232,72 @@ class MailProcessorService:
             f"model={options.model} sys_prompt_sha={_sp_sha_text}"
         )
 
-        # Send query via run_query_collect — one-shot, structured output
+        # Send query via run_query_collect — one-shot, structured output.
+        # ak-wty: F12 "Fatal error in message reader" is transient on
+        # ~5-10% of chunk runs under production load. Backoff-retry up
+        # to MAX_RETRIES on a known-transient signature; if all
+        # attempts fail (or the error is non-retryable) fall through
+        # to the existing error-return path. A structured log records
+        # the fileID + chunk indices + attempt count so a follow-up
+        # sweep can find any file that exhausted its retry budget.
+        import asyncio as _asyncio
+        from utils.sdk_retry import (
+            MAX_RETRIES,
+            is_retryable_sdk_error,
+            retry_delay_seconds,
+        )
         run_result = await run_query_collect(
             agent="pdf.text", options=options, prompt=prompt_text,
         )
+        attempts_used = 1
+        while (
+            run_result.error
+            and is_retryable_sdk_error(run_result.error)
+            and attempts_used <= MAX_RETRIES
+        ):
+            delay = retry_delay_seconds(attempts_used - 1)
+            self.logger.warning(
+                f"ak-wty: transient SDK error on chunk "
+                f"{page_start}-{page_end} (file_id={preset_file_id!r}) "
+                f"attempt {attempts_used}/{MAX_RETRIES + 1}: "
+                f"{run_result.error!r}. Sleeping {delay}s and retrying."
+            )
+            await _asyncio.sleep(delay)
+            attempts_used += 1
+            run_result = await run_query_collect(
+                agent="pdf.text", options=options, prompt=prompt_text,
+            )
         structured_data = run_result.structured_output
         fallback_text = run_result.text
         error_msg = run_result.error
         self.logger.info(
             f"Chunk {page_start}-{page_end} run: "
             f"has_structured_output={structured_data is not None}, "
-            f"text_chars={len(fallback_text)}, error={bool(error_msg)}"
+            f"text_chars={len(fallback_text)}, error={bool(error_msg)}, "
+            f"attempts_used={attempts_used}"
         )
 
         if error_msg:
+            # ak-wty: retries exhausted (or non-retryable error).
+            # Log with all the observability fields so a follow-up
+            # sweep can find the file.
             self.logger.error(
-                f"Text chunk error (pages {page_start}-{page_end}): {error_msg}"
+                f"ak-wty: text chunk error unresolved after "
+                f"{attempts_used} attempt(s). "
+                f"file_id={preset_file_id!r} pages={page_start}-{page_end} "
+                f"retryable={is_retryable_sdk_error(error_msg)} "
+                f"error={error_msg!r}"
             )
-            return {"called": False, "inserted": 0, "duplicates": 0}
+            return {
+                "called": False,
+                "inserted": 0,
+                "duplicates": 0,
+                # ak-wty: expose the retry counts + failure signal to
+                # callers (e.g. _run_all_chunks_async) so they can
+                # tag the file / bump per-chunk failure counters.
+                "sdk_retry_attempts": attempts_used,
+                "sdk_error": error_msg,
+            }
 
         # Fallback: if structured_output is None, try parsing AssistantMessage text
         if structured_data is None and fallback_text:

--- a/services/mailProcessorService.py
+++ b/services/mailProcessorService.py
@@ -2058,6 +2058,38 @@ class MailProcessorService:
                     f"all transactions."
                 )
                 hdfc_mask = None
+                # ak-dby: when the detector misses (regex doesn't
+                # match any SAVINGS header — the exact pathology of
+                # the 2026 Vidish_Raj_ layout), the full-text
+                # fallback re-admits non-savings sub-account rows
+                # into the savings fileID. Mark the file so the
+                # /admin/stripFallbackRows endpoint (ak-ex2) picks it
+                # up on the next re-parse sweep. Same pattern as the
+                # ak-ifc-v3 file-level reconciliation fallback path,
+                # different trigger.
+                #
+                # Only mark when we have a preset_file_id — if the
+                # extractor is running against an ad-hoc PDF path
+                # (rare, non-pipeline), there's no fileDetails row
+                # to tag.
+                if preset_file_id:
+                    try:
+                        self.transaction_service.mark_reconciliation_fallback(
+                            preset_file_id, user_id=user_id,
+                        )
+                        self.logger.info(
+                            f"ak-dby: tagged fileID={preset_file_id!r} "
+                            f"reconciliation_fallback=True (savings_spans=0 "
+                            f"detector miss) so /admin/stripFallbackRows "
+                            f"can clean up leaked non-savings tx."
+                        )
+                    except Exception as e:  # pragma: no cover — defensive
+                        self.logger.warning(
+                            f"ak-dby: mark_reconciliation_fallback failed "
+                            f"for fileID={preset_file_id!r}: {e}. Data "
+                            f"lands regardless; strip endpoint won't fire "
+                            f"until the file is tagged manually."
+                        )
 
         # Now pull the chunk's text, annotate each line with its
         # file-level line number so the LLM can echo the correct

--- a/services/mailProcessorService.py
+++ b/services/mailProcessorService.py
@@ -168,11 +168,34 @@ class MailProcessorService:
         doc.close()
 
         if needs_pass and not password:
+            # ak-nyd: try the per-file override FIRST. Some PDFs are
+            # protected with a value that doesn't match the bank's
+            # personal-info strategy (e.g. F6 Jan-2026 HDFC, Overseer
+            # set a custom password). The per_file_passwords config
+            # is a JSON-backed dict keyed on gmail_id and/or fileID.
+            # Falls through cleanly if the config is absent or has no
+            # matching entry.
             try:
-                password = self._try_personal_info_passwords(user_id, pdf_path)
+                from utils.per_file_passwords import lookup_password
+                password = lookup_password(gmail_id=gmail_id)
+                if password:
+                    self.logger.info(
+                        f"ak-nyd: applying per-file password override "
+                        f"for gmail_id={gmail_id!r}"
+                    )
             except Exception as e:
-                self.logger.warning(f"Password lookup failed: {e}")
+                self.logger.warning(
+                    f"ak-nyd per-file password lookup failed: {e}"
+                )
                 password = None
+
+            # Fall back to the bank's personal-info strategy.
+            if not password:
+                try:
+                    password = self._try_personal_info_passwords(user_id, pdf_path)
+                except Exception as e:
+                    self.logger.warning(f"Password lookup failed: {e}")
+                    password = None
             if not password:
                 return {"error": "PDF is password-protected and no password could be determined"}
             # Pre-unlock

--- a/test_per_file_passwords.py
+++ b/test_per_file_passwords.py
@@ -184,6 +184,139 @@ class TestEnvPathResolution(unittest.TestCase):
                 pass
 
 
+# ── ak-nyd v2: security hygiene (file/dir modes + default path) ─────
+
+
+import stat
+
+
+class TestFileModeIsOwnerOnly(_TmpStoreCase):
+    """ak-nyd v2 MAJOR: passwords file MUST be 0o600 after every
+    write. Umask can't override — _save_raw runs an explicit chmod
+    BEFORE and AFTER the atomic rename."""
+
+    def test_new_file_is_0o600(self):
+        add_password("secret", gmail_id="gm_mode1", path=self.path)
+        mode = stat.S_IMODE(os.stat(self.path).st_mode)
+        self.assertEqual(
+            mode, 0o600, f"expected 0o600, got 0o{mode:o}",
+        )
+
+    def test_updated_file_stays_0o600(self):
+        """Simulate an operator/attacker widening the mode — the
+        next write must tighten it back."""
+        add_password("s1", gmail_id="gm_mode2", path=self.path)
+        os.chmod(self.path, 0o644)
+        add_password("s2", gmail_id="gm_mode2", path=self.path)
+        mode = stat.S_IMODE(os.stat(self.path).st_mode)
+        self.assertEqual(mode, 0o600)
+
+    def test_remove_write_preserves_0o600(self):
+        add_password("s", gmail_id="gm_a", file_id="f_a", path=self.path)
+        os.chmod(self.path, 0o666)
+        remove_password(gmail_id="gm_a", path=self.path)
+        mode = stat.S_IMODE(os.stat(self.path).st_mode)
+        self.assertEqual(mode, 0o600)
+
+
+class TestParentDirCreated0o700(unittest.TestCase):
+    """When _save_raw creates the parent dir it must be 0o700."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.path = os.path.join(
+            self.tmpdir, "nested_ak_nyd_v2", "creds.json",
+        )
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_parent_dir_is_0o700(self):
+        add_password("s", gmail_id="gm_dir", path=self.path)
+        parent = os.path.dirname(self.path)
+        self.assertTrue(os.path.isdir(parent))
+        mode = stat.S_IMODE(os.stat(parent).st_mode)
+        self.assertEqual(
+            mode, 0o700,
+            f"expected parent dir 0o700, got 0o{mode:o}",
+        )
+
+
+class TestDefaultPathOutsideRepo(unittest.TestCase):
+    """ak-nyd v2 MAJOR: v1 defaulted to ./per_file_passwords.json —
+    landing plaintext creds next to the source tree with git
+    watching. v2 default is ~/.config/akkountant/per_file_passwords.json."""
+
+    def test_default_path_is_under_home_config(self):
+        from utils.per_file_passwords import _default_config_path
+        home = os.path.expanduser("~")
+        expected = os.path.join(
+            home, ".config", "akkountant", "per_file_passwords.json",
+        )
+        self.assertEqual(_default_config_path(), expected)
+
+    def test_default_path_not_under_cwd(self):
+        """Belt-and-braces — the default must NOT be a CWD-relative
+        path even if the operator runs from an unusual dir."""
+        from utils.per_file_passwords import _default_config_path
+        default = _default_config_path()
+        self.assertTrue(os.path.isabs(default))
+        cwd = os.getcwd()
+        self.assertFalse(
+            default.startswith(cwd + os.sep),
+            f"default path {default!r} unexpectedly under cwd {cwd!r}",
+        )
+
+    def test_resolve_config_path_env_override(self):
+        """The env var still wins over the ak-nyd v2 default."""
+        from utils.per_file_passwords import _resolve_config_path
+        original = os.environ.get("AK_PER_FILE_PASSWORDS_PATH")
+        try:
+            os.environ["AK_PER_FILE_PASSWORDS_PATH"] = "/tmp/custom_creds.json"
+            self.assertEqual(
+                _resolve_config_path(), "/tmp/custom_creds.json"
+            )
+        finally:
+            if original is not None:
+                os.environ["AK_PER_FILE_PASSWORDS_PATH"] = original
+            else:
+                os.environ.pop("AK_PER_FILE_PASSWORDS_PATH", None)
+
+    def test_resolve_config_path_no_env_uses_home_default(self):
+        from utils.per_file_passwords import (
+            _resolve_config_path, _default_config_path,
+        )
+        original = os.environ.get("AK_PER_FILE_PASSWORDS_PATH")
+        try:
+            os.environ.pop("AK_PER_FILE_PASSWORDS_PATH", None)
+            self.assertEqual(_resolve_config_path(), _default_config_path())
+        finally:
+            if original is not None:
+                os.environ["AK_PER_FILE_PASSWORDS_PATH"] = original
+
+
+class TestGitignoreEntry(unittest.TestCase):
+    """ak-nyd v2 defense-in-depth: the backend .gitignore blocks
+    per_file_passwords.json at any depth so an operator running an
+    old (pre-v2) CLI whose default path was CWD-relative can't
+    accidentally commit the file."""
+
+    def test_gitignore_blocks_per_file_passwords(self):
+        gi = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), ".gitignore",
+        )
+        self.assertTrue(os.path.exists(gi), ".gitignore missing")
+        with open(gi, "r") as f:
+            content = f.read()
+        # Either bare-name or /-anchored entry is acceptable — reject
+        # only if NEITHER is present.
+        self.assertTrue(
+            "per_file_passwords.json" in content,
+            ".gitignore must include per_file_passwords.json entry"
+        )
+
+
 if __name__ == "__main__":
     print("ak-nyd per-file password override tests")
     print("=" * 60)

--- a/test_per_file_passwords.py
+++ b/test_per_file_passwords.py
@@ -1,0 +1,191 @@
+"""ak-nyd regression tests — per-file PDF password override.
+
+MVP-scope JSON store for per-file password overrides. See
+utils/per_file_passwords.py for design. These tests exercise the
+pure-Python lookup/upsert/remove path against a temp config file.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from utils.per_file_passwords import (
+    add_password,
+    list_entries,
+    lookup_password,
+    remove_password,
+)
+
+
+class _TmpStoreCase(unittest.TestCase):
+    """Base test case that provides a temp JSON config path for each
+    test."""
+
+    def setUp(self):
+        fd, self.path = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        os.remove(self.path)  # start clean
+
+    def tearDown(self):
+        try:
+            os.remove(self.path)
+        except FileNotFoundError:
+            pass
+
+
+class TestLookupOnEmpty(_TmpStoreCase):
+    """Missing / empty config returns None. Never blows up."""
+
+    def test_missing_file_returns_none(self):
+        self.assertIsNone(lookup_password(gmail_id="gm1", path=self.path))
+        self.assertIsNone(lookup_password(file_id="f1", path=self.path))
+
+    def test_neither_key_returns_none(self):
+        add_password("pw", gmail_id="gm1", path=self.path)
+        self.assertIsNone(lookup_password(path=self.path))
+
+
+class TestUpsert(_TmpStoreCase):
+    """add_password writes to disk; lookup finds it."""
+
+    def test_add_by_gmail_id(self):
+        add_password("secret1", gmail_id="gm1", path=self.path)
+        self.assertEqual(
+            lookup_password(gmail_id="gm1", path=self.path), "secret1"
+        )
+
+    def test_add_by_file_id(self):
+        add_password("secret2", file_id="f1", path=self.path)
+        self.assertEqual(
+            lookup_password(file_id="f1", path=self.path), "secret2"
+        )
+
+    def test_add_by_both_writes_two_entries(self):
+        add_password("secret3", gmail_id="gm2", file_id="f2", path=self.path)
+        self.assertEqual(
+            lookup_password(gmail_id="gm2", path=self.path), "secret3"
+        )
+        self.assertEqual(
+            lookup_password(file_id="f2", path=self.path), "secret3"
+        )
+        entries = list_entries(path=self.path)
+        self.assertEqual(len(entries), 2)
+        self.assertIn("gmail_id:gm2", entries)
+        self.assertIn("file_id:f2", entries)
+
+    def test_upsert_overwrites(self):
+        add_password("oldpw", gmail_id="gm3", path=self.path)
+        add_password("newpw", gmail_id="gm3", path=self.path)
+        self.assertEqual(
+            lookup_password(gmail_id="gm3", path=self.path), "newpw"
+        )
+
+    def test_empty_password_raises(self):
+        with self.assertRaises(ValueError):
+            add_password("", gmail_id="gm4", path=self.path)
+
+    def test_no_key_raises(self):
+        with self.assertRaises(ValueError):
+            add_password("pw", path=self.path)
+
+
+class TestLookupPreference(_TmpStoreCase):
+    """When both gmail_id and file_id have entries, gmail_id wins in
+    the two-arg lookup — matches the reprocess_pdf caller shape."""
+
+    def test_gmail_id_preferred(self):
+        add_password("gm_pw", gmail_id="gm5", path=self.path)
+        add_password("file_pw", file_id="f5", path=self.path)
+        got = lookup_password(gmail_id="gm5", file_id="f5", path=self.path)
+        self.assertEqual(got, "gm_pw")
+
+    def test_falls_back_to_file_id_if_no_gmail_id_entry(self):
+        add_password("file_pw", file_id="f6", path=self.path)
+        got = lookup_password(gmail_id="gm-not-present", file_id="f6",
+                              path=self.path)
+        self.assertEqual(got, "file_pw")
+
+
+class TestRemove(_TmpStoreCase):
+    """remove_password strips entries idempotently."""
+
+    def test_remove_by_gmail_id(self):
+        add_password("pw", gmail_id="gm7", path=self.path)
+        self.assertTrue(remove_password(gmail_id="gm7", path=self.path))
+        self.assertIsNone(lookup_password(gmail_id="gm7", path=self.path))
+
+    def test_remove_missing_is_noop(self):
+        self.assertFalse(remove_password(gmail_id="never", path=self.path))
+
+    def test_remove_by_both(self):
+        add_password("pw", gmail_id="gm8", file_id="f8", path=self.path)
+        self.assertTrue(
+            remove_password(gmail_id="gm8", file_id="f8", path=self.path)
+        )
+        self.assertIsNone(lookup_password(gmail_id="gm8", path=self.path))
+        self.assertIsNone(lookup_password(file_id="f8", path=self.path))
+
+
+class TestCorruptConfig(_TmpStoreCase):
+    """Corrupt / non-dict JSON must not raise — defensive default."""
+
+    def test_non_dict_json_returns_empty(self):
+        with open(self.path, "w") as f:
+            f.write("[1, 2, 3]")
+        self.assertIsNone(
+            lookup_password(gmail_id="anything", path=self.path)
+        )
+
+    def test_garbage_returns_empty(self):
+        with open(self.path, "w") as f:
+            f.write("{ this is not valid json")
+        self.assertIsNone(
+            lookup_password(gmail_id="anything", path=self.path)
+        )
+
+    def test_corrupt_config_add_still_works(self):
+        """A corrupt file gets overwritten cleanly on the next
+        add_password call — we don't want prior corruption to block
+        recovery."""
+        with open(self.path, "w") as f:
+            f.write("{ broken")
+        add_password("pw", gmail_id="gm_recovery", path=self.path)
+        self.assertEqual(
+            lookup_password(gmail_id="gm_recovery", path=self.path), "pw"
+        )
+
+
+class TestEnvPathResolution(unittest.TestCase):
+    """AK_PER_FILE_PASSWORDS_PATH env var overrides the default cwd
+    lookup."""
+
+    def test_env_var_takes_precedence(self):
+        fd, tmp = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        os.remove(tmp)
+        original = os.environ.get("AK_PER_FILE_PASSWORDS_PATH")
+        try:
+            os.environ["AK_PER_FILE_PASSWORDS_PATH"] = tmp
+            # Explicit path=None → resolver picks up env var.
+            add_password("envpw", gmail_id="gm_env")
+            self.assertEqual(lookup_password(gmail_id="gm_env"), "envpw")
+        finally:
+            if original is not None:
+                os.environ["AK_PER_FILE_PASSWORDS_PATH"] = original
+            else:
+                os.environ.pop("AK_PER_FILE_PASSWORDS_PATH", None)
+            try:
+                os.remove(tmp)
+            except FileNotFoundError:
+                pass
+
+
+if __name__ == "__main__":
+    print("ak-nyd per-file password override tests")
+    print("=" * 60)
+    unittest.main(verbosity=2, exit=False)
+    print("=" * 60)

--- a/test_sdk_retry.py
+++ b/test_sdk_retry.py
@@ -1,0 +1,179 @@
+"""ak-wty regression tests — SDK retry policy.
+
+Pure-Python coverage of the retry-decision helpers in
+utils/sdk_retry.py. The service-layer integration
+(services/mailProcessorService.py) exercises the same helpers in an
+async loop; env-limited on the worktree Python (no SDK / no flask).
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from utils.sdk_retry import (
+    MAX_RETRIES,
+    is_retryable_sdk_error,
+    retry_delay_seconds,
+)
+
+
+class TestIsRetryableSignatures(unittest.TestCase):
+    """Known-transient error signatures return True."""
+
+    def test_fatal_error_message_reader(self):
+        """F12 canonical signature — the whole reason ak-wty exists."""
+        self.assertTrue(
+            is_retryable_sdk_error("Fatal error in message reader")
+        )
+
+    def test_case_insensitive(self):
+        for form in (
+            "FATAL ERROR IN MESSAGE READER",
+            "fatal error in message reader",
+            "Fatal Error In Message Reader",
+        ):
+            with self.subTest(form=form):
+                self.assertTrue(is_retryable_sdk_error(form))
+
+    def test_broader_message_reader_match(self):
+        self.assertTrue(
+            is_retryable_sdk_error("message reader interrupted")
+        )
+
+    def test_stream_error(self):
+        self.assertTrue(is_retryable_sdk_error("stream reset by server"))
+
+    def test_connection_error(self):
+        self.assertTrue(
+            is_retryable_sdk_error("connection reset by peer")
+        )
+
+    def test_timeout_error(self):
+        self.assertTrue(is_retryable_sdk_error("read timed out"))
+        self.assertTrue(is_retryable_sdk_error("request timeout"))
+        self.assertTrue(is_retryable_sdk_error("deadline exceeded"))
+
+    def test_rate_limit(self):
+        self.assertTrue(is_retryable_sdk_error("rate_limit exceeded"))
+        self.assertTrue(is_retryable_sdk_error("Rate Limit reached"))
+
+    def test_5xx_wrapper(self):
+        self.assertTrue(is_retryable_sdk_error("500 server error"))
+        self.assertTrue(is_retryable_sdk_error("internal error"))
+        self.assertTrue(
+            is_retryable_sdk_error("temporarily unavailable")
+        )
+
+    def test_stream_eof(self):
+        self.assertTrue(is_retryable_sdk_error("unexpected EOF"))
+        self.assertTrue(is_retryable_sdk_error("broken pipe"))
+
+
+class TestIsRetryableNonRetryable(unittest.TestCase):
+    """Terminal error signatures return False — a retry would just
+    fail again and burn time."""
+
+    def test_schema_validation(self):
+        """Structured-output schema validation failures don't retry —
+        the LLM's response doesn't match the JSON schema and a
+        second call likely produces the same shape."""
+        self.assertFalse(
+            is_retryable_sdk_error("schema validation failed")
+        )
+
+    def test_auth_401(self):
+        self.assertFalse(
+            is_retryable_sdk_error("401 unauthorized")
+        )
+
+    def test_auth_403(self):
+        self.assertFalse(is_retryable_sdk_error("403 forbidden"))
+
+    def test_invalid_request(self):
+        self.assertFalse(
+            is_retryable_sdk_error("invalid_request bad model")
+        )
+
+    def test_authentication_failure(self):
+        self.assertFalse(
+            is_retryable_sdk_error("authentication error")
+        )
+
+    def test_permission_denied(self):
+        self.assertFalse(
+            is_retryable_sdk_error("permission denied on model")
+        )
+
+    def test_non_retryable_takes_priority_over_retryable(self):
+        """If a message contains BOTH retryable and non-retryable
+        signatures, the non-retryable path wins — safer default."""
+        self.assertFalse(
+            is_retryable_sdk_error(
+                "connection: schema validation failed"
+            )
+        )
+
+
+class TestIsRetryableFalseInputs(unittest.TestCase):
+    """Non-string / None / empty inputs return False."""
+
+    def test_none_returns_false(self):
+        self.assertFalse(is_retryable_sdk_error(None))
+
+    def test_empty_string_returns_false(self):
+        self.assertFalse(is_retryable_sdk_error(""))
+
+    def test_whitespace_only_returns_false(self):
+        self.assertFalse(is_retryable_sdk_error("   "))
+
+    def test_non_string_returns_false(self):
+        self.assertFalse(is_retryable_sdk_error(500))
+        self.assertFalse(is_retryable_sdk_error(["stream", "error"]))
+        self.assertFalse(is_retryable_sdk_error({"error": "stream"}))
+
+
+class TestRetryDelay(unittest.TestCase):
+    """Exponential backoff, capped."""
+
+    def test_first_retry_is_1s(self):
+        self.assertEqual(retry_delay_seconds(0), 1.0)
+
+    def test_second_retry_is_2s(self):
+        self.assertEqual(retry_delay_seconds(1), 2.0)
+
+    def test_third_retry_is_4s(self):
+        self.assertEqual(retry_delay_seconds(2), 4.0)
+
+    def test_capped_at_default(self):
+        # 2^20 = 1048576 — capped to default 30s.
+        self.assertEqual(retry_delay_seconds(20), 30.0)
+
+    def test_negative_attempt_treated_as_zero(self):
+        self.assertEqual(retry_delay_seconds(-1), 1.0)
+
+    def test_custom_base_and_cap(self):
+        # base=0.5 → 0.5, 1.0, 2.0
+        self.assertEqual(retry_delay_seconds(0, base=0.5), 0.5)
+        self.assertEqual(retry_delay_seconds(1, base=0.5), 1.0)
+        self.assertEqual(retry_delay_seconds(2, base=0.5), 2.0)
+        # cap=1.5 → clip at 1.5
+        self.assertEqual(retry_delay_seconds(10, base=1.0, cap=1.5), 1.5)
+
+
+class TestMaxRetriesConstant(unittest.TestCase):
+    """MAX_RETRIES defines the total retry ceiling."""
+
+    def test_max_retries_is_3(self):
+        """3 retries = 4 total attempts. Higher would hang the
+        pipeline on genuinely-broken chunks; lower would leak legit
+        transient failures."""
+        self.assertEqual(MAX_RETRIES, 3)
+
+
+if __name__ == "__main__":
+    print("ak-wty SDK retry policy regression tests")
+    print("=" * 60)
+    unittest.main(verbosity=2, exit=False)
+    print("=" * 60)

--- a/test_statement_sections.py
+++ b/test_statement_sections.py
@@ -847,6 +847,83 @@ class TestBroadenedRealisticMultiSection(unittest.TestCase):
         self.assertIn(SectionType.MUTUAL_FUND, sections)
 
 
+class TestFallbackTagDecision(unittest.TestCase):
+    """ak-dby v2: the fallback-flag on savings_spans==0 should ONLY
+    trigger when at least one NON-SAVINGS section was detected. A
+    pure single-account statement (no HDFC-combined-statement banner
+    headers at all) also produces savings_spans==0 but must NOT be
+    tagged — there's no non-savings contamination for the strip
+    endpoint to clean up.
+
+    This test locks the decision predicate the service layer applies:
+      tag = (savings_spans == 0) AND (non_savings_spans >= 1)
+    """
+
+    def _counts(self, text):
+        """Return (savings_spans, non_savings_spans). UNKNOWN is not
+        counted on either side — matches the mailProcessorService
+        branch's predicate exactly."""
+        spans = detect_hdfc_sections(text)
+        s = sum(1 for x in spans if x.section == SectionType.SAVINGS)
+        ns = sum(
+            1 for x in spans
+            if x.section not in (SectionType.SAVINGS, SectionType.UNKNOWN)
+        )
+        return s, ns
+
+    def test_pure_single_account_should_not_tag(self):
+        """Boring single-account HDFC savings statement without any
+        combined-statement banner headers. savings_spans=0 AND
+        non_savings_spans=0 → detector correctly saw nothing → do
+        NOT tag."""
+        text = "\n".join([
+            "HDFC Bank Statement",
+            "Account Holder: Vidish Rajkumar",
+            "01/04  Salary Credit  50000",
+            "02/04  Rent Payment  25000",
+        ])
+        savings, non_savings = self._counts(text)
+        self.assertEqual(savings, 0)
+        self.assertEqual(non_savings, 0)
+        # → predicate is False → NOT tagged.
+
+    def test_combined_missing_savings_header_should_tag(self):
+        """Combined statement where the SAVINGS header was missed
+        (regex failed) but the CC / FD headers matched. savings=0
+        AND non_savings>=1 → contamination present → TAG."""
+        text = "\n".join([
+            "HDFC Bank Combined Statement",
+            "01/04  savings row that leaks",
+            "Statement of Account for : CREDIT CARD",
+            "02/04  CC purchase  1500",
+            "Statement of Account for : FIXED DEPOSIT",
+            "03/04  FD interest  750",
+        ])
+        savings, non_savings = self._counts(text)
+        self.assertEqual(savings, 0)
+        self.assertGreaterEqual(non_savings, 1)
+        # → predicate is True → TAGGED.
+
+    def test_savings_detected_no_tag_needed(self):
+        """Normal case: SAVINGS header found. Detector worked;
+        mask fires normally; no fallback tag path exercised."""
+        text = "\n".join([
+            "Statement of Account for : SAVINGS ACCOUNT",
+            "01/04 row",
+            "Statement of Account for : CREDIT CARD",
+            "02/04 CC row",
+        ])
+        savings, non_savings = self._counts(text)
+        self.assertGreaterEqual(savings, 1)
+        # → savings_spans != 0 → fallback branch not taken.
+
+    def test_empty_text_should_not_tag(self):
+        """Empty raw text → no spans → not tagged."""
+        savings, non_savings = self._counts("")
+        self.assertEqual(savings, 0)
+        self.assertEqual(non_savings, 0)
+
+
 class TestNarrationDoesNotFalsePositive(unittest.TestCase):
     """ak-dby's bare-banner patterns are anchored to line start so a
     transaction narration mentioning "savings account" mid-line can't

--- a/test_statement_sections.py
+++ b/test_statement_sections.py
@@ -707,6 +707,194 @@ class TestReconciliationEndToEnd(unittest.TestCase):
         self.assertIn("debits", recon.reason)
 
 
+# ── ak-dby: broadened HDFC section-header patterns ─────────────────
+#
+# The pre-ak-dby regex only matched "Statement of Account for : X".
+# The 2026 Vidish_Raj_ monthly layout uses bare / abbreviated banners
+# instead (Savings Account / Savings A/C / Account: … (SAVINGS)),
+# which broke section detection on every 2026 file — falling back to
+# unfiltered extraction WITHOUT setting reconciliation_fallback=True.
+# These tests pin down the expanded patterns so a future regression
+# on any of them is loud.
+
+
+class TestBroadenedSavingsHeaders(unittest.TestCase):
+    """ak-dby: alternate SAVINGS header forms observed in 2026
+    HDFC monthly layouts."""
+
+    def _first_span(self, text):
+        spans = detect_hdfc_sections(text)
+        # Skip the leading UNKNOWN span if present.
+        for s in spans:
+            if s.section != SectionType.UNKNOWN:
+                return s
+        return None
+
+    def test_savings_account_bare(self):
+        text = "Header line\nSAVINGS ACCOUNT\nrow"
+        span = self._first_span(text)
+        self.assertIsNotNone(span)
+        self.assertEqual(span.section, SectionType.SAVINGS)
+
+    def test_savings_ac_abbrev(self):
+        text = "Header\nSAVINGS A/C 50100XXXX\nrow"
+        span = self._first_span(text)
+        self.assertIsNotNone(span)
+        self.assertEqual(span.section, SectionType.SAVINGS)
+
+    def test_savings_bank_account(self):
+        text = "Header\nSavings Bank Account\nrow"
+        span = self._first_span(text)
+        self.assertIsNotNone(span)
+        self.assertEqual(span.section, SectionType.SAVINGS)
+
+    def test_account_type_savings(self):
+        text = "Header\nAccount Type : Savings\nrow"
+        span = self._first_span(text)
+        self.assertIsNotNone(span)
+        self.assertEqual(span.section, SectionType.SAVINGS)
+
+    def test_parenthetical_savings(self):
+        text = "Header\nAccount: 50100XXXXX (SAVINGS)\nrow"
+        span = self._first_span(text)
+        self.assertIsNotNone(span)
+        self.assertEqual(span.section, SectionType.SAVINGS)
+
+
+class TestBroadenedCreditCardHeaders(unittest.TestCase):
+    def _first_span(self, text):
+        spans = detect_hdfc_sections(text)
+        for s in spans:
+            if s.section != SectionType.UNKNOWN:
+                return s
+        return None
+
+    def test_credit_card_account(self):
+        text = "Header\nCREDIT CARD ACCOUNT\nrow"
+        span = self._first_span(text)
+        self.assertEqual(span.section, SectionType.CREDIT_CARD)
+
+    def test_credit_card_ac(self):
+        text = "Header\nCredit Card A/C\nrow"
+        span = self._first_span(text)
+        self.assertEqual(span.section, SectionType.CREDIT_CARD)
+
+    def test_credit_card_statement_banner(self):
+        text = "Header\nCredit Card Statement\nrow"
+        span = self._first_span(text)
+        self.assertEqual(span.section, SectionType.CREDIT_CARD)
+
+
+class TestBroadenedFixedRecurringHeaders(unittest.TestCase):
+    """Both bare and abbreviated forms — with the RECURRING-before-
+    FIXED ordering guard intact so RD substrings don't hijack FD."""
+
+    def _all_sections(self, text):
+        return [s.section for s in detect_hdfc_sections(text)
+                if s.section != SectionType.UNKNOWN]
+
+    def test_fd_abbrev(self):
+        text = "Header\nFD A/C 12345\nrow"
+        sections = self._all_sections(text)
+        self.assertIn(SectionType.FIXED_DEPOSIT, sections)
+        self.assertNotIn(SectionType.RECURRING_DEPOSIT, sections)
+
+    def test_rd_abbrev(self):
+        text = "Header\nRD Account 55555\nrow"
+        sections = self._all_sections(text)
+        self.assertIn(SectionType.RECURRING_DEPOSIT, sections)
+        self.assertNotIn(SectionType.FIXED_DEPOSIT, sections)
+
+    def test_recurring_deposit_bare(self):
+        text = "Header\nRECURRING DEPOSIT ACCOUNT\nrow"
+        sections = self._all_sections(text)
+        self.assertIn(SectionType.RECURRING_DEPOSIT, sections)
+
+    def test_fixed_deposit_bare(self):
+        text = "Header\nFIXED DEPOSIT A/C\nrow"
+        sections = self._all_sections(text)
+        self.assertIn(SectionType.FIXED_DEPOSIT, sections)
+
+
+class TestBroadenedRealisticMultiSection(unittest.TestCase):
+    """Emulate the 2026 Vidish_Raj_ layout: a combined statement
+    where every section uses bare banner headers (no "Statement of
+    Account for" prefix). Detector must find every section."""
+
+    def test_2026_style_layout(self):
+        text = "\n".join([
+            "HDFC Bank Combined Statement",
+            "SAVINGS ACCOUNT 50100XXXXX",  # bare banner
+            "01/04  Salary Credit  50,000.00",
+            "02/04  UPI Payment  1,234.56",
+            "CREDIT CARD A/C",              # abbrev banner
+            "03/04  Amazon Purchase  2,500.00",
+            "FD A/C 22345",                 # FD abbrev
+            "05/04  FD Interest  750.00",
+            "RD ACCOUNT 33345",             # RD abbrev
+            "06/04  RD Deposit  5,000.00",
+            "MUTUAL FUND FOLIO 44345",      # MF folio banner
+            "07/04  MF NAV  120.50",
+        ])
+        sections = [
+            s.section for s in detect_hdfc_sections(text)
+            if s.section != SectionType.UNKNOWN
+        ]
+        self.assertIn(SectionType.SAVINGS, sections)
+        self.assertIn(SectionType.CREDIT_CARD, sections)
+        self.assertIn(SectionType.FIXED_DEPOSIT, sections)
+        self.assertIn(SectionType.RECURRING_DEPOSIT, sections)
+        self.assertIn(SectionType.MUTUAL_FUND, sections)
+
+
+class TestNarrationDoesNotFalsePositive(unittest.TestCase):
+    """ak-dby's bare-banner patterns are anchored to line start so a
+    transaction narration mentioning "savings account" mid-line can't
+    trip them. This test locks that anchor guarantee."""
+
+    def test_narration_with_savings_account_mid_line(self):
+        text = "Some txn narration mentioning savings account balance"
+        spans = detect_hdfc_sections(text)
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0].section, SectionType.UNKNOWN)
+
+    def test_narration_with_credit_card_mid_line(self):
+        text = "Payment to Amazon via credit card A/C"
+        spans = detect_hdfc_sections(text)
+        self.assertEqual(spans[0].section, SectionType.UNKNOWN)
+
+    def test_narration_with_fd_mid_line(self):
+        text = "Interest posting from FD Account renewal"
+        spans = detect_hdfc_sections(text)
+        self.assertEqual(spans[0].section, SectionType.UNKNOWN)
+
+    def test_leading_whitespace_still_matches(self):
+        """Anchors allow leading whitespace — indentation on banner
+        lines shouldn't hide a real section header."""
+        text = "Header\n   SAVINGS ACCOUNT 50100XXXX\nrow"
+        spans = detect_hdfc_sections(text)
+        savings = [s for s in spans if s.section == SectionType.SAVINGS]
+        self.assertTrue(savings)
+
+
+class TestExistingPatternsStillMatch(unittest.TestCase):
+    """Belt-and-braces regression guard: the canonical "Statement of
+    Account for : X" phrasings — which the 47 pre-existing tests
+    already cover — still match after ak-dby's additions."""
+
+    def test_canonical_savings(self):
+        text = "Header\nStatement of Account for : SAVINGS ACCOUNT\nrow"
+        spans = detect_hdfc_sections(text)
+        savings = [s for s in spans if s.section == SectionType.SAVINGS]
+        self.assertTrue(savings, "canonical SAVINGS phrasing regressed")
+
+    def test_canonical_credit_card(self):
+        text = "Header\nStatement for : CREDIT CARD\nrow"
+        spans = detect_hdfc_sections(text)
+        cc = [s for s in spans if s.section == SectionType.CREDIT_CARD]
+        self.assertTrue(cc, "canonical CREDIT_CARD phrasing regressed")
+
+
 if __name__ == "__main__":
     print("ak-ifc statement-section detector regression tests")
     print("=" * 60)

--- a/utils/per_file_passwords.py
+++ b/utils/per_file_passwords.py
@@ -16,9 +16,11 @@ proper store later"):
   password strings. Loaded on demand, cached per process. No DB /
   no schema change.
 
-  Path resolution order:
+  Path resolution order (ak-nyd v2 — reviewer BOUNCE hq-wisp-*):
     1. `AK_PER_FILE_PASSWORDS_PATH` env var if set.
-    2. `<cwd>/per_file_passwords.json` if it exists.
+    2. `~/.config/akkountant/per_file_passwords.json`
+       (XDG-style config dir OUTSIDE the repo — v1 defaulted to
+       CWD which is a landmine).
     3. Empty dict (safe default — lookups return None).
 
   The JSON shape is a flat map:
@@ -28,14 +30,26 @@ proper store later"):
     }
   Two namespaces so a caller with either key can hit the store.
 
-SECURITY NOTE:
+SECURITY (ak-nyd v2 — reviewer flagged three landmines in v1; all
+three fixed here):
 
-Passwords land plaintext on disk — no worse than the personal-info
-flow (which also uses plaintext DOB / PAN / phone segments as
-password candidates), but not great. A proper encrypted store is
-deferred until the pipeline has a full secrets story (probably
-alongside the ak-2ln umbrella work). For NOW: chmod 600 the file,
-put it outside git, and treat it as short-lived recovery scaffolding.
+  1. **0o600 mode on write.** _save_raw runs `os.chmod(path, 0o600)`
+     after every write so only the owning user can read/write.
+     Umask can't override — chmod is explicit. Parent dir is 0o700
+     when we create it.
+
+  2. **Default path outside the repo.** v1 landed
+     `./per_file_passwords.json` next to the source tree with git
+     watching. v2 default is
+     `~/.config/akkountant/per_file_passwords.json`.
+
+  3. **.gitignore entry.** The backend .gitignore blocks
+     `per_file_passwords.json` at any depth so an operator running
+     an old (pre-v2) CLI can't accidentally commit the file.
+
+  Deferred: proper encrypted-secrets store (probably alongside the
+  ak-2ln umbrella work). Passwords remain plaintext even under this
+  v2 hardening — the fixes above just narrow the exposure surface.
 
 Pure-Python (no framework deps) so it's testable without booting
 flask/SQLAlchemy.
@@ -51,14 +65,30 @@ from typing import Optional
 _ENV_PATH_VAR = "AK_PER_FILE_PASSWORDS_PATH"
 _DEFAULT_FILENAME = "per_file_passwords.json"
 
+# ak-nyd v2: default lives OUTSIDE the repo. XDG-style config dir
+# under $HOME.
+_DEFAULT_CONFIG_DIR_REL = os.path.join(".config", "akkountant")
+
+# ak-nyd v2 file / dir modes.
+_FILE_MODE = 0o600  # owner rw only
+_DIR_MODE = 0o700   # owner rwx only
+
+
+def _default_config_path() -> str:
+    """ak-nyd v2: resolve the OUT-OF-REPO default path.
+    Uses os.path.expanduser("~") so the path picks up the running
+    user's home dir."""
+    home = os.path.expanduser("~")
+    return os.path.join(home, _DEFAULT_CONFIG_DIR_REL, _DEFAULT_FILENAME)
+
 
 def _resolve_config_path() -> str:
     """Return the file path to load / save the JSON store from.
-    Order: env var, then <cwd>/per_file_passwords.json."""
+    Order: env var, then ak-nyd v2 default outside the repo."""
     env_path = os.environ.get(_ENV_PATH_VAR, "").strip()
     if env_path:
         return env_path
-    return os.path.join(os.getcwd(), _DEFAULT_FILENAME)
+    return _default_config_path()
 
 
 def _load_raw(path: Optional[str] = None) -> dict:
@@ -80,18 +110,49 @@ def _load_raw(path: Optional[str] = None) -> dict:
 
 
 def _save_raw(data: dict, path: Optional[str] = None) -> None:
-    """Overwrite the JSON file with `data`. Caller is responsible
-    for ensuring the containing dir exists; we create it if not."""
+    """Overwrite the JSON file with `data`. Enforces ak-nyd v2 file /
+    dir modes (0o600 on the file, 0o700 on the parent dir when we
+    create it).
+
+    Sequence:
+      1. Create parent dir if missing (0o700; won't tighten an
+         existing dir the operator manages).
+      2. Write to a `.tmp` sibling.
+      3. chmod the tmp to 0o600 BEFORE the rename — closes a
+         narrow race where a reader could open the file between
+         rename and chmod.
+      4. Atomic rename to the target path.
+      5. Belt-and-braces chmod of the final path — some
+         filesystems (or umask quirks) can drop the mode across
+         rename; explicit chmod covers those.
+    """
     if path is None:
         path = _resolve_config_path()
     parent = os.path.dirname(path)
     if parent and not os.path.exists(parent):
-        os.makedirs(parent, exist_ok=True)
+        os.makedirs(parent, mode=_DIR_MODE, exist_ok=True)
+        # os.makedirs honors mode only when creating — cascade a
+        # chmod on the final component so the mode is applied even
+        # if a parent already existed with a looser mode.
+        try:
+            os.chmod(parent, _DIR_MODE)
+        except OSError:
+            pass  # non-fatal
     tmp = f"{path}.tmp"
     with open(tmp, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, sort_keys=True)
         f.write("\n")
+    # ak-nyd v2: chmod BEFORE the rename so the file is 0o600 the
+    # instant it becomes visible under the final path.
+    try:
+        os.chmod(tmp, _FILE_MODE)
+    except OSError:
+        pass  # non-fatal — belt-and-braces chmod below covers this
     os.replace(tmp, path)
+    try:
+        os.chmod(path, _FILE_MODE)
+    except OSError:
+        pass  # non-fatal
 
 
 def lookup_password(

--- a/utils/per_file_passwords.py
+++ b/utils/per_file_passwords.py
@@ -1,0 +1,173 @@
+"""ak-nyd: per-file PDF password override.
+
+Some statement PDFs are password-protected with a value that doesn't
+match the bank's standard personal-info strategy (DOB, PAN, phone
+segments, etc.). F6 (Jan-2026 HDFC, recovered via
+recover_pdf_ak32o.py) is such a file — Overseer set a custom
+password on it. Without a per-file override, mailProcessor's
+_try_personal_info_passwords loop can't unlock it and the whole
+re-parse falls over.
+
+DESIGN (MVP per Lead's dispatch hq-wisp-6n526p — "simpler MVP first,
+proper store later"):
+
+  A JSON-backed dict keyed on gmail_id (matches reprocess_pdf's
+  parameter shape) and/or fileID. Values are the plaintext
+  password strings. Loaded on demand, cached per process. No DB /
+  no schema change.
+
+  Path resolution order:
+    1. `AK_PER_FILE_PASSWORDS_PATH` env var if set.
+    2. `<cwd>/per_file_passwords.json` if it exists.
+    3. Empty dict (safe default — lookups return None).
+
+  The JSON shape is a flat map:
+    {
+      "gmail_id:<gmail_message_id>": "password-string",
+      "file_id:<fileID>":            "password-string"
+    }
+  Two namespaces so a caller with either key can hit the store.
+
+SECURITY NOTE:
+
+Passwords land plaintext on disk — no worse than the personal-info
+flow (which also uses plaintext DOB / PAN / phone segments as
+password candidates), but not great. A proper encrypted store is
+deferred until the pipeline has a full secrets story (probably
+alongside the ak-2ln umbrella work). For NOW: chmod 600 the file,
+put it outside git, and treat it as short-lived recovery scaffolding.
+
+Pure-Python (no framework deps) so it's testable without booting
+flask/SQLAlchemy.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Optional
+
+
+_ENV_PATH_VAR = "AK_PER_FILE_PASSWORDS_PATH"
+_DEFAULT_FILENAME = "per_file_passwords.json"
+
+
+def _resolve_config_path() -> str:
+    """Return the file path to load / save the JSON store from.
+    Order: env var, then <cwd>/per_file_passwords.json."""
+    env_path = os.environ.get(_ENV_PATH_VAR, "").strip()
+    if env_path:
+        return env_path
+    return os.path.join(os.getcwd(), _DEFAULT_FILENAME)
+
+
+def _load_raw(path: Optional[str] = None) -> dict:
+    """Load the JSON file into a dict. Returns {} on missing file or
+    parse error (defensive — never blow up the caller because of a
+    corrupt config)."""
+    if path is None:
+        path = _resolve_config_path()
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return data
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_raw(data: dict, path: Optional[str] = None) -> None:
+    """Overwrite the JSON file with `data`. Caller is responsible
+    for ensuring the containing dir exists; we create it if not."""
+    if path is None:
+        path = _resolve_config_path()
+    parent = os.path.dirname(path)
+    if parent and not os.path.exists(parent):
+        os.makedirs(parent, exist_ok=True)
+    tmp = f"{path}.tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+        f.write("\n")
+    os.replace(tmp, path)
+
+
+def lookup_password(
+    gmail_id: Optional[str] = None,
+    file_id: Optional[str] = None,
+    *,
+    path: Optional[str] = None,
+) -> Optional[str]:
+    """ak-nyd: return the per-file password override for a given
+    gmail_id and/or fileID, or None if neither key is present.
+
+    Preference order (both keys resolve independently; caller picks):
+      1. `gmail_id:<gmail_id>` if `gmail_id` is supplied and present.
+      2. `file_id:<file_id>` if `file_id` is supplied and present.
+
+    Never raises. Missing config file → None. Corrupt config → None.
+    """
+    if not gmail_id and not file_id:
+        return None
+    data = _load_raw(path)
+    if gmail_id:
+        v = data.get(f"gmail_id:{gmail_id}")
+        if v:
+            return v
+    if file_id:
+        v = data.get(f"file_id:{file_id}")
+        if v:
+            return v
+    return None
+
+
+def add_password(
+    password: str,
+    *,
+    gmail_id: Optional[str] = None,
+    file_id: Optional[str] = None,
+    path: Optional[str] = None,
+) -> None:
+    """ak-nyd: upsert a password entry. At least one of gmail_id /
+    file_id must be provided. Both are written if both are supplied
+    (safe for callers with only one identifier)."""
+    if not gmail_id and not file_id:
+        raise ValueError(
+            "add_password: at least one of gmail_id or file_id required"
+        )
+    if not password:
+        raise ValueError("add_password: password must be non-empty")
+    data = _load_raw(path)
+    if gmail_id:
+        data[f"gmail_id:{gmail_id}"] = password
+    if file_id:
+        data[f"file_id:{file_id}"] = password
+    _save_raw(data, path)
+
+
+def remove_password(
+    *,
+    gmail_id: Optional[str] = None,
+    file_id: Optional[str] = None,
+    path: Optional[str] = None,
+) -> bool:
+    """Remove an entry. Returns True if anything was removed."""
+    if not gmail_id and not file_id:
+        return False
+    data = _load_raw(path)
+    removed = False
+    if gmail_id:
+        removed |= (data.pop(f"gmail_id:{gmail_id}", None) is not None)
+    if file_id:
+        removed |= (data.pop(f"file_id:{file_id}", None) is not None)
+    if removed:
+        _save_raw(data, path)
+    return removed
+
+
+def list_entries(path: Optional[str] = None) -> dict:
+    """Return a shallow copy of the current entries. Useful for
+    audit / CLI listing."""
+    return dict(_load_raw(path))

--- a/utils/sdk_retry.py
+++ b/utils/sdk_retry.py
@@ -1,0 +1,110 @@
+"""ak-wty: SDK retry policy for chunk-processing errors.
+
+F12's per-run non-determinism ("Fatal error in message reader" on
+chunks 3-4, per infra's [DIAG 5 ANOMALIES]) has the same signature
+as ak-8cp which we WONTFIX'd because it looked environmental. That
+call was too fast — under production load the error clearly retries
+successfully on the next attempt. Prior code swallowed the error and
+returned zero-count for the chunk, causing silent under-parse on the
+whole file.
+
+DESIGN:
+
+  is_retryable_sdk_error(error_msg) → bool
+    True iff the error signature matches a KNOWN-transient pattern.
+    Falses out on schema-validation / auth / structured-output
+    errors that would just fail again on retry.
+
+  retry_delay_seconds(attempt) → float
+    Exponential backoff, capped: 1s, 2s, 4s. attempt is 0-indexed
+    (0 = first retry, so delay before attempt 1).
+
+  MAX_RETRIES = 3
+    Total attempts including original = 4 (original + 3 retries).
+    Beyond that we log with fileID + chunk indices and bail.
+
+Pure-Python (no framework deps) so it's testable without booting
+the SDK client.
+"""
+
+from __future__ import annotations
+
+
+# 3 retries = 4 total attempts. Any higher and the pipeline hangs
+# on genuinely-broken chunks; any lower and legit transient failures
+# still leak through.
+MAX_RETRIES = 3
+
+# Substrings we RETRY on. All matched case-insensitively.
+_RETRYABLE_SIGNATURES = (
+    "fatal error in message reader",  # F12 canonical signature
+    "message reader",                  # broader match
+    "stream",                          # any streaming interrupt
+    "connection",                      # network hiccup
+    "timeout",                         # timeouts
+    "rate_limit",                      # rate-limit (retry after backoff)
+    "rate limit",                      # phrasing variant
+    "server error",                    # generic 5xx wrapper
+    "internal error",                  # generic 5xx wrapper
+    "temporarily unavailable",         # explicit transient
+    "temporary failure",
+    "read timed out",
+    "deadline exceeded",
+    "eof",                             # raw stream EOF
+    "broken pipe",
+)
+
+# Substrings we DO NOT retry on — these are terminal per attempt.
+_NON_RETRYABLE_SIGNATURES = (
+    "schema",                          # structured-output validation
+    "invalid_request",                 # 4xx malformed
+    "authentication",                  # bad creds
+    "unauthorized",                    # 401
+    "forbidden",                       # 403
+    "not found",                       # 404
+    "permission",                      # permission model rejection
+)
+
+
+def is_retryable_sdk_error(error_msg) -> bool:
+    """ak-wty predicate: return True iff `error_msg` matches a
+    known-transient signature. Non-string / None / empty inputs
+    return False.
+
+    Non-retryable signatures take PRIORITY — if the message hits
+    both a retryable and a non-retryable pattern (rare), we treat
+    it as non-retryable to avoid a retry storm on a genuinely
+    broken request.
+    """
+    if not error_msg or not isinstance(error_msg, str):
+        return False
+    lower = error_msg.lower()
+
+    # Non-retryable takes priority.
+    for sig in _NON_RETRYABLE_SIGNATURES:
+        if sig in lower:
+            return False
+
+    for sig in _RETRYABLE_SIGNATURES:
+        if sig in lower:
+            return True
+
+    return False
+
+
+def retry_delay_seconds(attempt: int, *, base: float = 1.0,
+                        cap: float = 30.0) -> float:
+    """ak-wty backoff: exponential 1s → 2s → 4s → …, capped.
+
+    attempt is 0-indexed:
+      attempt=0 → delay 1s before the first retry
+      attempt=1 → delay 2s before the second retry
+      attempt=2 → delay 4s before the third retry
+
+    The cap prevents pathological backoff on a very high retry
+    count (though MAX_RETRIES enforces the ceiling anyway).
+    """
+    if attempt < 0:
+        attempt = 0
+    delay = base * (2 ** attempt)
+    return min(delay, cap)

--- a/utils/statement_sections.py
+++ b/utils/statement_sections.py
@@ -64,15 +64,27 @@ class SectionType(str, Enum):
 # left-to-right, but we use a list of individual patterns so ordering
 # is explicit + auditable.
 #
-# We tolerate:
-#   - "Statement of Account for :"
-#   - "Statement for :"
-#   - "STATEMENT OF ACCOUNT FOR :" (all caps)
-#   - Trailing account number, mask, or extra whitespace
+# Header phrasings tolerated per section (ak-dby broadening):
+#   1. "Statement of Account for : X"  (canonical, existing)
+#   2. "Statement for : X"              (elided "of Account")
+#   3. "X Account"                      (bare, e.g. "Savings Account")
+#   4. "X A/C" or "X Bank Account"     (abbreviated forms)
+#   5. "Account Type: X"                (typed line)
+#   6. "Account: <num> (X)"             (parenthetical, ak-dby)
 #
-# The header is matched case-insensitively but the SectionType we
-# emit is normalized.
+# Case-insensitive. The SectionType we emit is normalized.
+#
+# ak-dby: the pre-ak-dby regex only matched shape (1) / (2). The
+# Vidish_Raj_2026 monthly layout uses shape (3) / (4) plus tabular
+# banners without the "Statement for" prefix, so every 2026 file
+# came back with savings_spans=0 and triggered the full-text
+# fallback. Fallback IS correct for zero-loss BUT before ak-dby the
+# fallback didn't set reconciliation_fallback=True, so the strip
+# endpoint never ran and non-savings sub-accounts leaked into the
+# savings fileID. See mailProcessorService's savings_span_count==0
+# branch for the flag-setting fix.
 _HDFC_SECTION_PATTERNS: list[tuple[SectionType, re.Pattern[str]]] = [
+    # ── SAVINGS ────────────────────────────────────────────────
     (
         SectionType.SAVINGS,
         re.compile(
@@ -81,12 +93,56 @@ _HDFC_SECTION_PATTERNS: list[tuple[SectionType, re.Pattern[str]]] = [
         ),
     ),
     (
+        SectionType.SAVINGS,
+        # ak-dby: bare "Savings Account" / "Savings A/C" /
+        # "Savings Bank Account" banner. Anchored to line start
+        # (^\s*) so a narration line mentioning "savings account
+        # balance" mid-string can't false-positive.
+        re.compile(
+            r"^\s*savings\s+(?:bank\s+)?(?:account|a\s*/?\s*c)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        SectionType.SAVINGS,
+        # ak-dby: "Account Type : Savings" typed line.
+        re.compile(
+            r"^\s*account\s+type\s*[:\-]?\s*savings",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        SectionType.SAVINGS,
+        # ak-dby: parenthetical "Account: 50100XXXX (SAVINGS)"
+        # form some HDFC combined layouts use.
+        re.compile(
+            r"^\s*account\s*[:\-]?[^\n]{0,60}\(\s*savings\s*\)",
+            re.IGNORECASE,
+        ),
+    ),
+    # ── CURRENT ────────────────────────────────────────────────
+    (
         SectionType.CURRENT,
         re.compile(
             r"statement\s+(?:of\s+account\s+)?for\s*:?\s*current",
             re.IGNORECASE,
         ),
     ),
+    (
+        SectionType.CURRENT,
+        re.compile(
+            r"^\s*current\s+(?:bank\s+)?(?:account|a\s*/?\s*c)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        SectionType.CURRENT,
+        re.compile(
+            r"^\s*account\s+type\s*[:\-]?\s*current",
+            re.IGNORECASE,
+        ),
+    ),
+    # ── CREDIT_CARD ────────────────────────────────────────────
     (
         SectionType.CREDIT_CARD,
         re.compile(
@@ -95,12 +151,40 @@ _HDFC_SECTION_PATTERNS: list[tuple[SectionType, re.Pattern[str]]] = [
         ),
     ),
     (
+        SectionType.CREDIT_CARD,
+        re.compile(
+            # "Credit Card Account", "Credit Card A/C",
+            # "Credit Card Statement" — banner variants. Anchored to
+            # line start to avoid narration false-positives.
+            r"^\s*credit\s*card\s+(?:account|a\s*/?\s*c|statement)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    # ── RECURRING_DEPOSIT (before FIXED_DEPOSIT — substring guard) ──
+    (
         SectionType.RECURRING_DEPOSIT,
         re.compile(
             r"statement\s+(?:of\s+account\s+)?for\s*:?\s*recurring\s*deposit",
             re.IGNORECASE,
         ),
     ),
+    (
+        SectionType.RECURRING_DEPOSIT,
+        re.compile(
+            r"^\s*recurring\s*deposit\s+(?:account|a\s*/?\s*c)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        SectionType.RECURRING_DEPOSIT,
+        re.compile(
+            # "RD A/C" or "RD Account" — the RD abbreviation on
+            # combined layouts.
+            r"^\s*rd\s+(?:account|a\s*/?\s*c)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    # ── FIXED_DEPOSIT ──────────────────────────────────────────
     (
         SectionType.FIXED_DEPOSIT,
         re.compile(
@@ -109,6 +193,22 @@ _HDFC_SECTION_PATTERNS: list[tuple[SectionType, re.Pattern[str]]] = [
         ),
     ),
     (
+        SectionType.FIXED_DEPOSIT,
+        re.compile(
+            r"^\s*fixed\s*deposit\s+(?:account|a\s*/?\s*c)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        SectionType.FIXED_DEPOSIT,
+        re.compile(
+            # "FD A/C" or "FD Account" — the FD abbreviation.
+            r"^\s*fd\s+(?:account|a\s*/?\s*c)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    # ── MUTUAL_FUND ────────────────────────────────────────────
+    (
         SectionType.MUTUAL_FUND,
         re.compile(
             r"statement\s+(?:of\s+account\s+)?for\s*:?\s*mutual\s*fund",
@@ -116,9 +216,24 @@ _HDFC_SECTION_PATTERNS: list[tuple[SectionType, re.Pattern[str]]] = [
         ),
     ),
     (
+        SectionType.MUTUAL_FUND,
+        re.compile(
+            r"^\s*mutual\s*fund\s+(?:account|a\s*/?\s*c|folio)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    # ── PPF ────────────────────────────────────────────────────
+    (
         SectionType.PPF,
         re.compile(
             r"statement\s+(?:of\s+account\s+)?for\s*:?\s*(?:ppf|public\s+provident)",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        SectionType.PPF,
+        re.compile(
+            r"^\s*(?:ppf|public\s+provident\s+fund)\s+(?:account|a\s*/?\s*c)\b",
             re.IGNORECASE,
         ),
     ),


### PR DESCRIPTION
Batch (dby+nyd+wty, 5 commits, 123/123 tests, reviewer-cleared): ak-dby broaden HDFC headers + reconciliation_fallback on savings_spans==0; ak-nyd secure per-file PDF password lookup (0o600 + gitignore + path outside repo — no secrets committed, verified); ak-wty SDK backoff-retry on transient chunk errors. Rebased on 64b6eac, 0 migration/destructive prereq. co:false.