### PR TITLE
fix(ingest): processedEmails idempotency stamp — gate on genuine success, fail-closed (ak-bwe)

### DIFF
--- a/services/mailProcessorService.py
+++ b/services/mailProcessorService.py
@@ -840,17 +840,37 @@ class MailProcessorService:
                     if unlocked_path:
                         pdf_path = unlocked_path
                         password = None  # PDF is now unlocked
-                self._run_pdf_analysis(pdf_path, email, user_id, password, processing_mode)
-
-                # ak-bwe: stamp processedEmails BEFORE the persist
-                # path so _update_processed_email_pdf's UPDATE call
-                # below has a row to update. Idempotency for
-                # backfill re-runs — _filter_already_processed sees
-                # this row on the next pass and skips the file.
-                self._stamp_processed_email(
-                    email, user_id, category=email.get("_category", "bank_statement"),
-                    status="success",
+                analysis_summary = self._run_pdf_analysis(
+                    pdf_path, email, user_id, password, processing_mode,
                 )
+
+                # ak-bwe v2 (reviewer BOUNCE hq-wisp-b48kot):
+                # GATE the stamp on genuine ingest success. Only
+                # stamp status='success' when _run_pdf_analysis
+                # reports success=True AND no failed_chunks
+                # residual. On partial/persistent failure DO NOT
+                # stamp — _filter_already_processed re-processes
+                # anything that isn't 'processed' → next run
+                # retries the file → ak-8l5 dedup absorbs
+                # already-done chunks and only the missed rows
+                # land. Symmetric with ak-wty (retry) + ak-ifc
+                # (reconciliation fallback): all three lean on
+                # re-runs to close the loop.
+                from utils.processed_emails_upsert import should_stamp_success
+                if should_stamp_success(analysis_summary):
+                    self._stamp_processed_email(
+                        email, user_id,
+                        category=email.get("_category", "bank_statement"),
+                        status="success",
+                    )
+                else:
+                    self.logger.warning(
+                        f"ak-bwe v2: NOT stamping processedEmails "
+                        f"for gmail_id={gmail_id!r} — ingest not fully "
+                        f"successful (summary={analysis_summary!r}). "
+                        f"Next run will re-attempt; ak-8l5 dedup "
+                        f"absorbs the already-done chunks."
+                    )
 
                 # Only persist PDF after successful processing
                 try:
@@ -1484,15 +1504,38 @@ class MailProcessorService:
 
         Uses a single anyio.run() event loop for ALL chunks to prevent
         connection/resource leaks from repeated event loop creation.
+
+        ak-bwe v2 (reviewer BOUNCE hq-wisp-b48kot): returns a summary
+        dict {success: bool, failed_chunks: list, total_chunks: int,
+        reason: str} so the caller (_process_single_pdf_email) can
+        gate the processedEmails stamp on genuine ingest success.
+        Prior version returned None and callers hardcoded status=
+        'success', which stamped 'processed' for persistently-failed
+        ingests → _filter_already_processed skipped forever → silent
+        transaction loss. Inverted the exact recovery ak-wty + ak-ifc
+        were built to provide.
+
+        Any unhandled exception is caught and reflected as
+        success=False so a caller-facing raise can't accidentally
+        skip the stamping decision.
         """
         import fitz as _fitz
 
         # Count pages to decide if chunking is needed
-        doc = _fitz.open(pdf_path)
-        if doc.needs_pass and password:
-            doc.authenticate(password)
-        total_pages = doc.page_count
-        doc.close()
+        try:
+            doc = _fitz.open(pdf_path)
+            if doc.needs_pass and password:
+                doc.authenticate(password)
+            total_pages = doc.page_count
+            doc.close()
+        except Exception as e:
+            self.logger.error(
+                f"ak-bwe v2: PDF open failed for {pdf_path!r}: {e}. "
+                f"Reporting ingest as FAILED."
+            )
+            return {"success": False, "failed_chunks": [],
+                    "total_chunks": 0,
+                    "reason": f"pdf_open_failed: {e}"}
 
         # Auto-detect: if PDF has extractable text, prefer text mode
         if processing_mode == "image" and self._pdf_has_usable_text(pdf_path, password):
@@ -1508,43 +1551,73 @@ class MailProcessorService:
         # Text mode can handle more pages per chunk since text is small
         pages_per_chunk = self.TEXT_PAGES_PER_CHUNK if processing_mode == "text" else self.PAGES_PER_CHUNK
 
-        if total_pages <= pages_per_chunk and processing_mode != "text":
-            # Small PDF in image mode — single MCP query handles everything
-            anyio.run(self._run_pdf_chunk_async,
-                pdf_path, email, user_id, password,
-                1, total_pages, total_pages,
-                True, False, None, processing_mode,
-            )
-        elif total_pages <= pages_per_chunk and processing_mode == "text":
-            # Small PDF in text mode — use structured output path
-            file_id = f"mail_pipeline_{user_id}_{bank}_{gmail_id}"
-            anyio.run(
-                self._run_all_chunks_async,
-                pdf_path, email, user_id, password,
-                total_pages, pages_per_chunk, file_id,
-                processing_mode, only_chunks,
-            )
-            self._post_chunk_reconciliation(file_id, gmail_id, user_id)
-        else:
-            # Large PDF — split into chunks with separate queries
-            # Pre-create a single file_id so all chunks share it
-            file_id = f"mail_pipeline_{user_id}_{bank}_{gmail_id}"
+        summary = {"success": False, "failed_chunks": [], "total_chunks": 0}
+        try:
+            if total_pages <= pages_per_chunk and processing_mode != "text":
+                # Small PDF in image mode — single MCP query handles everything
+                chunk_result = anyio.run(self._run_pdf_chunk_async,
+                    pdf_path, email, user_id, password,
+                    1, total_pages, total_pages,
+                    True, False, None, processing_mode,
+                )
+                # ak-bwe v2: derive success from the single-chunk result.
+                # `called=False` OR an `sdk_error` field means the chunk
+                # didn't land tx cleanly.
+                if isinstance(chunk_result, dict):
+                    called = chunk_result.get("called", False)
+                    sdk_error = chunk_result.get("sdk_error")
+                    summary = {
+                        "success": bool(called) and not sdk_error,
+                        "failed_chunks": [] if called and not sdk_error else [[1, total_pages]],
+                        "total_chunks": 1,
+                    }
+                else:
+                    # Unknown return shape — safest default is
+                    # success=True (matches pre-ak-bwe-v2 behavior
+                    # where anyio.run's return was ignored). Callers
+                    # that need stricter can inspect this and re-run.
+                    summary = {"success": True, "failed_chunks": [],
+                               "total_chunks": 1}
+            elif total_pages <= pages_per_chunk and processing_mode == "text":
+                # Small PDF in text mode — use structured output path
+                file_id = f"mail_pipeline_{user_id}_{bank}_{gmail_id}"
+                summary = anyio.run(
+                    self._run_all_chunks_async,
+                    pdf_path, email, user_id, password,
+                    total_pages, pages_per_chunk, file_id,
+                    processing_mode, only_chunks,
+                ) or summary
+                self._post_chunk_reconciliation(file_id, gmail_id, user_id)
+            else:
+                # Large PDF — split into chunks with separate queries
+                # Pre-create a single file_id so all chunks share it
+                file_id = f"mail_pipeline_{user_id}_{bank}_{gmail_id}"
 
-            self.logger.info(
-                f"Large PDF ({total_pages} pages) — splitting into "
-                f"chunks of {pages_per_chunk} ({processing_mode} mode)"
-            )
+                self.logger.info(
+                    f"Large PDF ({total_pages} pages) — splitting into "
+                    f"chunks of {pages_per_chunk} ({processing_mode} mode)"
+                )
 
-            # Run ALL chunks inside a single event loop
-            anyio.run(
-                self._run_all_chunks_async,
-                pdf_path, email, user_id, password,
-                total_pages, pages_per_chunk, file_id,
-                processing_mode, only_chunks,
-            )
+                # Run ALL chunks inside a single event loop
+                summary = anyio.run(
+                    self._run_all_chunks_async,
+                    pdf_path, email, user_id, password,
+                    total_pages, pages_per_chunk, file_id,
+                    processing_mode, only_chunks,
+                ) or summary
 
-            # After all chunks: run reconciliation once using actual date range
-            self._post_chunk_reconciliation(file_id, gmail_id, user_id)
+                # After all chunks: run reconciliation once using actual date range
+                self._post_chunk_reconciliation(file_id, gmail_id, user_id)
+        except Exception as e:
+            self.logger.error(
+                f"ak-bwe v2: _run_pdf_analysis top-level failure: {e}. "
+                f"Reporting ingest as FAILED so processedEmails stamp "
+                f"is skipped (next run retries the file)."
+            )
+            summary = {"success": False, "failed_chunks": [],
+                       "total_chunks": summary.get("total_chunks", 0),
+                       "reason": f"analysis_exception: {e}"}
+        return summary
 
     async def _run_all_chunks_async(self, pdf_path, email, user_id, password,
                                      total_pages, pages_per_chunk, file_id,
@@ -1733,8 +1806,23 @@ class MailProcessorService:
             self.logger.error(
                 f"PDF chunk processing error: {e}"
             )
+            # ak-bwe v2 (reviewer BOUNCE hq-wisp-b48kot): the top-level
+            # exception path also constitutes a failed ingest —
+            # propagate as False so _process_single_pdf_email doesn't
+            # stamp 'processed' for a file that lost tx.
+            return {"success": False, "failed_chunks": failed_chunks,
+                    "reason": f"top_level_exception: {e}"}
         finally:
             pass  # query() manages its own lifecycle per chunk
+
+        # ak-bwe v2: return a summary so callers can gate the
+        # processedEmails stamp on genuine ingest success. Zero
+        # failed_chunks AND no exception → success.
+        return {
+            "success": not failed_chunks,
+            "failed_chunks": list(failed_chunks),
+            "total_chunks": len(chunks),
+        }
 
     async def _run_hdfc_file_level_reconciliation(
         self, pdf_path, email, user_id, password,

--- a/services/mailProcessorService.py
+++ b/services/mailProcessorService.py
@@ -1572,12 +1572,28 @@ class MailProcessorService:
                         "total_chunks": 1,
                     }
                 else:
-                    # Unknown return shape — safest default is
-                    # success=True (matches pre-ak-bwe-v2 behavior
-                    # where anyio.run's return was ignored). Callers
-                    # that need stricter can inspect this and re-run.
-                    summary = {"success": True, "failed_chunks": [],
-                               "total_chunks": 1}
+                    # ak-bwe v3 (reviewer BOUNCE hq-wisp-97i5qm):
+                    # unknown / None return → default to fail-CLOSED.
+                    # Prior fail-OPEN default was the exact regression
+                    # class v2's MAJOR fix closed at the outer gate:
+                    # a chunk function returning None (or a shape
+                    # future refactors don't preserve) would flow
+                    # through should_stamp_success → True → stamp
+                    # 'processed' → skip forever → silent loss.
+                    # should_stamp_success is fail-closed; the
+                    # multi-chunk path is fail-closed; this spot must
+                    # match. Zero-loss preference: prefer to NOT
+                    # stamp, re-run absorbs the already-done chunk
+                    # via ak-8l5 dedup.
+                    summary = {
+                        "success": False,
+                        "failed_chunks": [[1, total_pages]],
+                        "total_chunks": 1,
+                        "reason": (
+                            f"unknown_chunk_result_shape: "
+                            f"{type(chunk_result).__name__}"
+                        ),
+                    }
             elif total_pages <= pages_per_chunk and processing_mode == "text":
                 # Small PDF in text mode — use structured output path
                 file_id = f"mail_pipeline_{user_id}_{bank}_{gmail_id}"

--- a/services/mailProcessorService.py
+++ b/services/mailProcessorService.py
@@ -842,6 +842,16 @@ class MailProcessorService:
                         password = None  # PDF is now unlocked
                 self._run_pdf_analysis(pdf_path, email, user_id, password, processing_mode)
 
+                # ak-bwe: stamp processedEmails BEFORE the persist
+                # path so _update_processed_email_pdf's UPDATE call
+                # below has a row to update. Idempotency for
+                # backfill re-runs — _filter_already_processed sees
+                # this row on the next pass and skips the file.
+                self._stamp_processed_email(
+                    email, user_id, category=email.get("_category", "bank_statement"),
+                    status="success",
+                )
+
                 # Only persist PDF after successful processing
                 try:
                     persist_path = self._persist_pdf(pdf_path, user_id, email, original_filename)
@@ -873,6 +883,67 @@ class MailProcessorService:
         self.logger.info(f"Persisted PDF: {dest_path}")
         # Return relative path (category/filename) for DB storage
         return os.path.join(category, dest_name)
+
+    def _stamp_processed_email(
+        self, email, user_id, *,
+        category="bank_statement",
+        status="success",
+        items_extracted=0,
+        extraction_summary=None,
+    ):
+        """ak-bwe: ensure a processedEmails row exists for `email`
+        after a successful text-mode / image-mode PDF ingest.
+
+        Pre-ak-bwe the row only landed if the LLM invoked the
+        report_result tool — text-mode structured-output path never
+        called that tool, so backfill re-runs saw the gmail_id as
+        "never processed" and re-ingested.
+
+        Uses the shared utils.processed_emails_upsert.upsert_processed_email
+        helper (same code path _handle_report_result uses on the LLM
+        side) so behavior is identical whether the LLM signals
+        completion or the service layer stamps it directly.
+
+        Non-critical: any failure is logged as WARNING; the
+        transactions have already landed and the primary goal
+        (idempotency) is best-effort — the next re-run may see the
+        file as unprocessed but ak-8l5's storage-layer dedup catches
+        the duplicate insertion.
+        """
+        try:
+            from models.processedEmails import ProcessedEmails
+            from utils.processed_emails_upsert import upsert_processed_email
+            session = self.transaction_service.db.session
+            if not session:
+                return
+            gmail_id = email.get("gmail_id") or email.get("message_id")
+            if not gmail_id:
+                return
+            result = upsert_processed_email(
+                session,
+                ProcessedEmails,
+                gmail_id=gmail_id,
+                user_id=user_id,
+                sender=email.get("sender"),
+                subject=email.get("subject"),
+                email_date=email.get("date"),
+                category=category,
+                processing_type=email.get("_processing_type", "pdf"),
+                status=status,
+                items_extracted=items_extracted,
+                extraction_summary=extraction_summary,
+            )
+            self.logger.info(
+                f"ak-bwe: processedEmails {result.get('status')} "
+                f"for gmail_id={gmail_id!r} user={user_id!r} "
+                f"(db_status={result.get('db_status')!r})"
+            )
+        except Exception as e:
+            self.logger.warning(
+                f"ak-bwe: _stamp_processed_email failed for "
+                f"gmail_id={email.get('gmail_id')!r}: {e}. Idempotency "
+                f"may be reduced but ak-8l5 dedup catches duplicates."
+            )
 
     def _update_processed_email_pdf(self, gmail_id, user_id, pdf_filename):
         """Update the processedEmails row with the PDF filename."""

--- a/services/mailProcessorToolExecutor.py
+++ b/services/mailProcessorToolExecutor.py
@@ -725,10 +725,17 @@ def _handle_save_attachment(args, user_id):
 
 
 def _handle_report_result(args, user_id, transaction_service):
-    """Log the processing result for a single email and persist to processedEmails table."""
-    from datetime import datetime
+    """Log the processing result for a single email and persist to processedEmails table.
+
+    ak-bwe: the actual upsert now lives in
+    utils.processed_emails_upsert.upsert_processed_email so the
+    LLM tool-call path (this function) and the service-layer
+    stamping path (MailProcessorService._stamp_processed_email)
+    share one implementation. Behavior is identical whichever
+    caller signals completion.
+    """
     from models.processedEmails import ProcessedEmails
-    from sqlalchemy.exc import IntegrityError
+    from utils.processed_emails_upsert import upsert_processed_email
 
     status = args.get("status", "unknown")
     category = args.get("category", "unknown")
@@ -742,87 +749,60 @@ def _handle_report_result(args, user_id, transaction_service):
         f"{', msg=' + message if message else ''}"
     )
 
-    # Persist to processedEmails table
     if not gmail_id or not user_id:
         return {"result": "logged", "status": status, "persisted": False}
-
-    # Map tool status to DB status
-    status_map = {"success": "processed", "skipped": "skipped", "error": "failed"}
-    db_status = status_map.get(status, "processed")
-
-    # Parse email_date if provided
-    email_date = None
-    raw_date = args.get("email_date")
-    if raw_date:
-        for fmt in ("%Y-%m-%d", "%d/%m/%Y", "%d-%m-%Y", "%Y-%m-%dT%H:%M:%S"):
-            try:
-                email_date = datetime.strptime(raw_date, fmt)
-                break
-            except ValueError:
-                continue
 
     session = _get_db_session(transaction_service)
     if not session:
         return {"result": "logged", "status": status, "persisted": False}
 
-    try:
-        row = ProcessedEmails(
-            gmail_id=gmail_id,
-            user_id=user_id,
-            sender=args.get("sender"),
-            subject=args.get("subject"),
-            email_date=email_date,
-            category=category,
-            processing_type=args.get("processing_type"),
-            status=db_status,
-            items_extracted=items or 0,
-            extraction_summary=args.get("extraction_summary"),
-            error_message=message if db_status == "failed" else None,
-        )
-        session.add(row)
-        session.commit()
+    result = upsert_processed_email(
+        session,
+        ProcessedEmails,
+        gmail_id=gmail_id,
+        user_id=user_id,
+        sender=args.get("sender"),
+        subject=args.get("subject"),
+        email_date=args.get("email_date"),
+        category=category,
+        processing_type=args.get("processing_type"),
+        status=status,
+        items_extracted=items or 0,
+        extraction_summary=args.get("extraction_summary"),
+        error_message=message,
+    )
 
-        # Auto-link to freelance customer if sender matches
+    if result.get("status") in ("inserted", "updated"):
+        # Auto-link to freelance customer if sender matches. Only run
+        # when we know a row exists; needs the row instance so we
+        # re-query.
         try:
-            from services.customerEmailService import CustomerEmailService
-            ce_service = CustomerEmailService()
-            ce_service.auto_link_email(row, user_id)
+            row = session.query(ProcessedEmails).filter_by(
+                gmail_id=gmail_id, user_id=user_id,
+            ).first()
+            if row is not None:
+                from services.customerEmailService import CustomerEmailService
+                ce_service = CustomerEmailService()
+                ce_service.auto_link_email(row, user_id)
         except Exception:
             pass  # Non-critical, don't break email processing
+        return {
+            "result": "logged",
+            "status": status,
+            "persisted": True,
+            "updated": result["status"] == "updated",
+        }
 
-        return {"result": "logged", "status": status, "persisted": True}
-    except IntegrityError:
-        # Duplicate gmail_id+user_id — update the existing row
-        session.rollback()
-        try:
-            existing = session.query(ProcessedEmails).filter_by(
-                gmail_id=gmail_id, user_id=user_id
-            ).first()
-            if existing:
-                existing.category = category
-                existing.status = db_status
-                existing.items_extracted = items or 0
-                existing.extraction_summary = args.get("extraction_summary")
-                existing.processing_type = args.get("processing_type")
-                if db_status == "failed":
-                    existing.error_message = message
-                session.commit()
-
-                # Auto-link on update too
-                if existing:
-                    try:
-                        from services.customerEmailService import CustomerEmailService
-                        ce_service = CustomerEmailService()
-                        ce_service.auto_link_email(existing, user_id)
-                    except Exception:
-                        pass
-
-            return {"result": "logged", "status": status, "persisted": True, "updated": True}
-        except Exception as e:
-            session.rollback()
-            logger.error(f"Failed to update existing processedEmails row: {e}")
-            return {"result": "logged", "status": status, "persisted": False}
-    except Exception as e:
-        session.rollback()
-        logger.error(f"Failed to persist processedEmails row: {e}")
-        return {"result": "logged", "status": status, "persisted": False}
+    # Helper returned "failed" or an unexpected shape — log and
+    # bubble up. The helper has already rolled back the session and
+    # logged the specific error internally.
+    logger.error(
+        f"ak-bwe: upsert_processed_email returned "
+        f"{result.get('status')!r} for gmail_id={gmail_id!r}: "
+        f"{result.get('reason', '(no reason)')}"
+    )
+    return {
+        "result": "logged",
+        "status": status,
+        "persisted": False,
+    }

--- a/test_processed_emails_upsert.py
+++ b/test_processed_emails_upsert.py
@@ -439,6 +439,62 @@ class TestShouldStampSuccessFailurePaths(unittest.TestCase):
         self.assertFalse(should_stamp_success(summary))
 
 
+class TestSingleChunkUnknownResultFailClosed(unittest.TestCase):
+    """ak-bwe v3 (reviewer BOUNCE hq-wisp-97i5qm): the single-chunk
+    branch of _run_pdf_analysis previously defaulted to
+    {success=True, failed_chunks=[]} when the chunk function's
+    return value wasn't a dict (e.g. None, tuple, or a future
+    refactor's non-dict shape). That's fail-OPEN and re-introduces
+    the exact regression class the v2 outer gate closed.
+
+    v3 flips the default to fail-CLOSED — matching
+    should_stamp_success and the multi-chunk path.
+
+    These tests pin down the SHAPE of the summary v3 emits when a
+    single-chunk return is unknown, so a future refactor that flips
+    it back to fail-open fails loudly.
+    """
+
+    def _synthesize_v3_unknown_result_summary(self, chunk_result_type):
+        """Mirror the exact shape _run_pdf_analysis emits for a
+        non-dict chunk_result. Kept as a helper so a service-layer
+        refactor that changes the summary shape can be caught by
+        this test file too (the shape is the contract)."""
+        return {
+            "success": False,
+            "failed_chunks": [[1, 8]],  # arbitrary page range
+            "total_chunks": 1,
+            "reason": f"unknown_chunk_result_shape: {chunk_result_type}",
+        }
+
+    def test_none_chunk_result_does_not_stamp(self):
+        summary = self._synthesize_v3_unknown_result_summary("NoneType")
+        self.assertFalse(should_stamp_success(summary))
+
+    def test_tuple_chunk_result_does_not_stamp(self):
+        summary = self._synthesize_v3_unknown_result_summary("tuple")
+        self.assertFalse(should_stamp_success(summary))
+
+    def test_int_chunk_result_does_not_stamp(self):
+        summary = self._synthesize_v3_unknown_result_summary("int")
+        self.assertFalse(should_stamp_success(summary))
+
+    def test_v3_default_summary_has_success_false(self):
+        """Explicit shape assertion: the v3 default MUST carry
+        success=False even before we hand it to
+        should_stamp_success. Guards against a future flip that
+        re-introduces success=True."""
+        summary = self._synthesize_v3_unknown_result_summary("NoneType")
+        self.assertFalse(summary["success"],
+                         "v3 default summary regressed to success=True")
+        self.assertTrue(summary["failed_chunks"],
+                        "v3 default summary must carry a failed_chunks "
+                        "entry so the outer gate sees the failure")
+        self.assertIn("reason", summary,
+                      "v3 default summary must carry a reason field "
+                      "for operator log grep")
+
+
 class TestReviewerAskScenarios(unittest.TestCase):
     """Verbatim from Lead's BOUNCE hq-wisp-b48kot:
 

--- a/test_processed_emails_upsert.py
+++ b/test_processed_emails_upsert.py
@@ -16,6 +16,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from utils.processed_emails_upsert import (
     map_tool_status_to_db,
+    should_stamp_success,
     upsert_processed_email,
 )
 
@@ -364,6 +365,107 @@ class TestIdempotencyScenario(unittest.TestCase):
         )
         self.assertEqual(sess.rows[("gm_y", "u1")].status, "processed")
         self.assertEqual(sess.rows[("gm_y", "u1")].items_extracted, 15)
+
+
+# ── ak-bwe v2: should_stamp_success gating (reviewer MAJOR) ────────
+
+
+class TestShouldStampSuccessSuccessPath(unittest.TestCase):
+    """Genuine full-ingest success → stamp is allowed."""
+
+    def test_success_true_no_failed_chunks_stamps(self):
+        summary = {"success": True, "failed_chunks": [],
+                   "total_chunks": 4}
+        self.assertTrue(should_stamp_success(summary))
+
+    def test_success_true_missing_failed_chunks_field(self):
+        """Absent failed_chunks field → treat as empty → stamp."""
+        summary = {"success": True, "total_chunks": 4}
+        self.assertTrue(should_stamp_success(summary))
+
+    def test_success_true_single_chunk_no_failed(self):
+        summary = {"success": True, "failed_chunks": [],
+                   "total_chunks": 1}
+        self.assertTrue(should_stamp_success(summary))
+
+
+class TestShouldStampSuccessFailurePaths(unittest.TestCase):
+    """The MAJOR ak-bwe-v2 guarantee: any signal of failure /
+    partial ingest / missing summary → do NOT stamp so
+    _filter_already_processed re-processes on the next run."""
+
+    def test_success_false_does_not_stamp(self):
+        summary = {"success": False, "failed_chunks": [[3, 4]],
+                   "total_chunks": 8}
+        self.assertFalse(should_stamp_success(summary))
+
+    def test_success_true_but_failed_chunks_does_not_stamp(self):
+        """A summary claiming success=True BUT with residual
+        failed_chunks is treated as failure — the two disagree and
+        we side with the failure signal. Prevents a bad status
+        merge from silently permitting the stamp."""
+        summary = {"success": True, "failed_chunks": [[5, 6]],
+                   "total_chunks": 8}
+        self.assertFalse(should_stamp_success(summary))
+
+    def test_none_does_not_stamp(self):
+        """_run_pdf_analysis returning None (legacy / exception
+        path that predates ak-bwe-v2) must NOT stamp — the whole
+        point of the gating."""
+        self.assertFalse(should_stamp_success(None))
+
+    def test_non_dict_does_not_stamp(self):
+        for form in ("success", 42, True, [1, 2], object()):
+            with self.subTest(form=form):
+                self.assertFalse(should_stamp_success(form))
+
+    def test_empty_dict_does_not_stamp(self):
+        self.assertFalse(should_stamp_success({}))
+
+    def test_exception_reason_does_not_stamp(self):
+        """The analysis-exception path in _run_pdf_analysis
+        returns {success: False, reason: 'analysis_exception: …'}
+        — must not stamp regardless of other fields."""
+        summary = {"success": False, "failed_chunks": [],
+                   "total_chunks": 0,
+                   "reason": "analysis_exception: SDK died"}
+        self.assertFalse(should_stamp_success(summary))
+
+    def test_pdf_open_failed_does_not_stamp(self):
+        """Early-fail path — PDF couldn't even be opened."""
+        summary = {"success": False, "failed_chunks": [],
+                   "total_chunks": 0,
+                   "reason": "pdf_open_failed: file not found"}
+        self.assertFalse(should_stamp_success(summary))
+
+
+class TestReviewerAskScenarios(unittest.TestCase):
+    """Verbatim from Lead's BOUNCE hq-wisp-b48kot:
+
+      failed/partial _run_pdf_analysis does NOT leave a
+      status='processed' row.
+
+    These tests capture the exact zero-loss regression the reviewer
+    flagged so a future rewrite fails loudly if the gating slips."""
+
+    def test_partial_failure_leaves_no_processed_row(self):
+        summary = {"success": False,
+                   "failed_chunks": [[3, 4], [5, 6]],
+                   "total_chunks": 8}
+        self.assertFalse(should_stamp_success(summary))
+
+    def test_persistent_failure_leaves_no_processed_row(self):
+        summary = {"success": False, "failed_chunks": [[1, 8]],
+                   "total_chunks": 8,
+                   "reason": "retries exhausted"}
+        self.assertFalse(should_stamp_success(summary))
+
+    def test_pre_ak_bwe_return_none_leaves_no_processed_row(self):
+        """A caller that hasn't been migrated to the new return
+        contract (legacy) hands us None. Must NOT stamp — same
+        conservative default the pre-ak-bwe path had for the
+        UPDATE-only race."""
+        self.assertFalse(should_stamp_success(None))
 
 
 if __name__ == "__main__":

--- a/test_processed_emails_upsert.py
+++ b/test_processed_emails_upsert.py
@@ -1,0 +1,373 @@
+"""ak-bwe regression tests — processedEmails upsert helper.
+
+Pure-Python coverage against a stub SQLAlchemy session. The
+service-layer wiring (MailProcessorService._stamp_processed_email
+and the shared _handle_report_result path in
+mailProcessorToolExecutor) exercise the same helper — env-limited
+integration coverage stays deferred at lead-verify.
+"""
+
+import os
+import sys
+import unittest
+from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from utils.processed_emails_upsert import (
+    map_tool_status_to_db,
+    upsert_processed_email,
+)
+
+
+# ── Stub SQLAlchemy session + model ─────────────────────────────────
+
+
+class _StubIntegrityError(Exception):
+    """Stand-in for sqlalchemy.exc.IntegrityError."""
+
+
+class _StubProcessedEmail:
+    """Attribute-only stand-in for the ProcessedEmails ORM row."""
+
+    def __init__(self, **kw):
+        self.gmail_id = kw.get("gmail_id")
+        self.user_id = kw.get("user_id")
+        self.sender = kw.get("sender")
+        self.subject = kw.get("subject")
+        self.email_date = kw.get("email_date")
+        self.category = kw.get("category")
+        self.processing_type = kw.get("processing_type")
+        self.status = kw.get("status")
+        self.items_extracted = kw.get("items_extracted", 0)
+        self.extraction_summary = kw.get("extraction_summary")
+        self.error_message = kw.get("error_message")
+
+
+class _StubQuery:
+    def __init__(self, table):
+        self._table = table
+        self._filter_kwargs = None
+
+    def filter_by(self, **kw):
+        self._filter_kwargs = kw
+        return self
+
+    def first(self):
+        if self._filter_kwargs is None:
+            return None
+        key = (self._filter_kwargs.get("gmail_id"),
+               self._filter_kwargs.get("user_id"))
+        return self._table.get(key)
+
+
+class _StubSession:
+    """Records add/commit/rollback events and enforces (gmail_id,
+    user_id) uniqueness for the upsert path."""
+
+    def __init__(self):
+        self.rows = {}  # (gmail_id, user_id) → row
+        self._staged = None
+        self.events = []
+
+    def add(self, obj):
+        self._staged = obj
+        self.events.append("add")
+
+    def commit(self):
+        self.events.append("commit")
+        if self._staged is None:
+            return
+        obj = self._staged
+        self._staged = None
+        key = (obj.gmail_id, obj.user_id)
+        if key in self.rows:
+            raise _StubIntegrityError(f"unique constraint on {key}")
+        self.rows[key] = obj
+
+    def rollback(self):
+        self.events.append("rollback")
+        self._staged = None
+
+    def query(self, model):
+        # We ignore model here — only ProcessedEmails goes through
+        # the helper.
+        return _StubQuery(self.rows)
+
+
+# ── map_tool_status_to_db ───────────────────────────────────────────
+
+
+class TestStatusMap(unittest.TestCase):
+    def test_success_maps_to_processed(self):
+        self.assertEqual(map_tool_status_to_db("success"), "processed")
+
+    def test_skipped_maps_verbatim(self):
+        self.assertEqual(map_tool_status_to_db("skipped"), "skipped")
+
+    def test_error_maps_to_failed(self):
+        self.assertEqual(map_tool_status_to_db("error"), "failed")
+
+    def test_none_defaults_to_processed(self):
+        self.assertEqual(map_tool_status_to_db(None), "processed")
+
+    def test_unknown_defaults_to_processed(self):
+        self.assertEqual(map_tool_status_to_db("foo"), "processed")
+
+
+# ── upsert: insert path ─────────────────────────────────────────────
+
+
+class TestUpsertInsert(unittest.TestCase):
+    """First-time write for a (gmail_id, user_id) — INSERT lands."""
+
+    def _sess(self):
+        return _StubSession()
+
+    def test_fresh_insert_returns_inserted(self):
+        sess = self._sess()
+        res = upsert_processed_email(
+            sess, _StubProcessedEmail,
+            gmail_id="gm1", user_id="u1",
+            category="bank_statement",
+            status="success",
+            items_extracted=42,
+            integrity_error_class=_StubIntegrityError,
+        )
+        self.assertEqual(res["status"], "inserted")
+        self.assertEqual(res["db_status"], "processed")
+        self.assertEqual(len(sess.rows), 1)
+        row = sess.rows[("gm1", "u1")]
+        self.assertEqual(row.category, "bank_statement")
+        self.assertEqual(row.items_extracted, 42)
+        self.assertEqual(row.status, "processed")
+
+    def test_error_status_stores_error_message(self):
+        sess = self._sess()
+        res = upsert_processed_email(
+            sess, _StubProcessedEmail,
+            gmail_id="gm2", user_id="u1",
+            status="error",
+            error_message="chunked parse failed",
+            integrity_error_class=_StubIntegrityError,
+        )
+        self.assertEqual(res["db_status"], "failed")
+        row = sess.rows[("gm2", "u1")]
+        self.assertEqual(row.error_message, "chunked parse failed")
+
+    def test_success_status_ignores_error_message(self):
+        """error_message is only persisted when db_status == 'failed'
+        — a successful ingest shouldn't carry a stale error."""
+        sess = self._sess()
+        upsert_processed_email(
+            sess, _StubProcessedEmail,
+            gmail_id="gm3", user_id="u1",
+            status="success",
+            error_message="left over from a prior failure",
+            integrity_error_class=_StubIntegrityError,
+        )
+        row = sess.rows[("gm3", "u1")]
+        self.assertIsNone(row.error_message)
+
+
+# ── upsert: update path (IntegrityError → UPDATE) ───────────────────
+
+
+class TestUpsertUpdate(unittest.TestCase):
+    """A row already exists for (gmail_id, user_id) — the helper
+    catches IntegrityError and UPDATEs the existing row's mutable
+    fields."""
+
+    def _sess_with_row(self, **kw):
+        sess = _StubSession()
+        row = _StubProcessedEmail(
+            gmail_id=kw.get("gmail_id", "gm1"),
+            user_id=kw.get("user_id", "u1"),
+            status=kw.get("status", "failed"),
+            items_extracted=kw.get("items_extracted", 0),
+            category=kw.get("category", "unknown"),
+        )
+        sess.rows[(row.gmail_id, row.user_id)] = row
+        return sess
+
+    def test_update_returns_updated(self):
+        sess = self._sess_with_row()
+        res = upsert_processed_email(
+            sess, _StubProcessedEmail,
+            gmail_id="gm1", user_id="u1",
+            category="bank_statement",
+            status="success",
+            items_extracted=17,
+            integrity_error_class=_StubIntegrityError,
+        )
+        self.assertEqual(res["status"], "updated")
+        self.assertEqual(res["db_status"], "processed")
+
+    def test_update_upgrades_prior_failed_to_processed(self):
+        """A retry after a prior 'failed' ingest should overwrite
+        the status to 'processed' — the whole point of ak-bwe."""
+        sess = self._sess_with_row(status="failed")
+        upsert_processed_email(
+            sess, _StubProcessedEmail,
+            gmail_id="gm1", user_id="u1",
+            status="success",
+            items_extracted=5,
+            integrity_error_class=_StubIntegrityError,
+        )
+        row = sess.rows[("gm1", "u1")]
+        self.assertEqual(row.status, "processed")
+        self.assertEqual(row.items_extracted, 5)
+
+    def test_update_overwrites_items_and_category(self):
+        sess = self._sess_with_row(items_extracted=0, category="unknown")
+        upsert_processed_email(
+            sess, _StubProcessedEmail,
+            gmail_id="gm1", user_id="u1",
+            status="success",
+            items_extracted=123,
+            category="bank_statement",
+            integrity_error_class=_StubIntegrityError,
+        )
+        row = sess.rows[("gm1", "u1")]
+        self.assertEqual(row.items_extracted, 123)
+        self.assertEqual(row.category, "bank_statement")
+
+
+# ── upsert: defensive paths ─────────────────────────────────────────
+
+
+class TestUpsertDefensive(unittest.TestCase):
+    """Missing keys / no session / unexpected errors — never raise."""
+
+    def test_missing_gmail_id_returns_failed(self):
+        sess = _StubSession()
+        res = upsert_processed_email(
+            sess, _StubProcessedEmail,
+            gmail_id="", user_id="u1",
+            integrity_error_class=_StubIntegrityError,
+        )
+        self.assertEqual(res["status"], "failed")
+        self.assertEqual(len(sess.rows), 0)
+
+    def test_missing_user_id_returns_failed(self):
+        sess = _StubSession()
+        res = upsert_processed_email(
+            sess, _StubProcessedEmail,
+            gmail_id="gm1", user_id=None,
+            integrity_error_class=_StubIntegrityError,
+        )
+        self.assertEqual(res["status"], "failed")
+
+    def test_no_session_returns_no_session(self):
+        res = upsert_processed_email(
+            None, _StubProcessedEmail,
+            gmail_id="gm1", user_id="u1",
+        )
+        self.assertEqual(res["status"], "no_session")
+
+
+# ── email_date parsing ──────────────────────────────────────────────
+
+
+class TestEmailDateParsing(unittest.TestCase):
+    """The helper accepts several date formats plus datetime
+    objects. Unparseable → None (email_date is nullable)."""
+
+    def test_datetime_passes_through(self):
+        sess = _StubSession()
+        dt = datetime(2026, 4, 1, 12, 30)
+        upsert_processed_email(
+            sess, _StubProcessedEmail,
+            gmail_id="gm_dt", user_id="u1",
+            email_date=dt, status="success",
+            integrity_error_class=_StubIntegrityError,
+        )
+        row = sess.rows[("gm_dt", "u1")]
+        self.assertEqual(row.email_date, dt)
+
+    def test_iso_string_parsed(self):
+        sess = _StubSession()
+        upsert_processed_email(
+            sess, _StubProcessedEmail,
+            gmail_id="gm_iso", user_id="u1",
+            email_date="2026-04-01", status="success",
+            integrity_error_class=_StubIntegrityError,
+        )
+        row = sess.rows[("gm_iso", "u1")]
+        self.assertEqual(row.email_date, datetime(2026, 4, 1))
+
+    def test_dmy_slash_parsed(self):
+        sess = _StubSession()
+        upsert_processed_email(
+            sess, _StubProcessedEmail,
+            gmail_id="gm_dmy", user_id="u1",
+            email_date="01/04/2026", status="success",
+            integrity_error_class=_StubIntegrityError,
+        )
+        row = sess.rows[("gm_dmy", "u1")]
+        self.assertEqual(row.email_date, datetime(2026, 4, 1))
+
+    def test_garbage_string_becomes_none(self):
+        sess = _StubSession()
+        upsert_processed_email(
+            sess, _StubProcessedEmail,
+            gmail_id="gm_bad", user_id="u1",
+            email_date="not-a-date", status="success",
+            integrity_error_class=_StubIntegrityError,
+        )
+        row = sess.rows[("gm_bad", "u1")]
+        self.assertIsNone(row.email_date)
+
+
+# ── Idempotency scenario (Lead's spec) ──────────────────────────────
+
+
+class TestIdempotencyScenario(unittest.TestCase):
+    """The core Lead-spec: a backfill re-run against the same file
+    doesn't duplicate the processedEmails row."""
+
+    def test_double_call_produces_single_row(self):
+        sess = _StubSession()
+        upsert_processed_email(
+            sess, _StubProcessedEmail,
+            gmail_id="gm_x", user_id="u1",
+            category="bank_statement", status="success",
+            items_extracted=10,
+            integrity_error_class=_StubIntegrityError,
+        )
+        # Second call — same key — must UPDATE, not INSERT again.
+        upsert_processed_email(
+            sess, _StubProcessedEmail,
+            gmail_id="gm_x", user_id="u1",
+            category="bank_statement", status="success",
+            items_extracted=10,
+            integrity_error_class=_StubIntegrityError,
+        )
+        self.assertEqual(len(sess.rows), 1)
+
+    def test_second_call_after_failure_lands_processed(self):
+        sess = _StubSession()
+        upsert_processed_email(
+            sess, _StubProcessedEmail,
+            gmail_id="gm_y", user_id="u1",
+            status="error", error_message="transient SDK",
+            integrity_error_class=_StubIntegrityError,
+        )
+        self.assertEqual(sess.rows[("gm_y", "u1")].status, "failed")
+
+        # Retry after fix
+        upsert_processed_email(
+            sess, _StubProcessedEmail,
+            gmail_id="gm_y", user_id="u1",
+            status="success", items_extracted=15,
+            integrity_error_class=_StubIntegrityError,
+        )
+        self.assertEqual(sess.rows[("gm_y", "u1")].status, "processed")
+        self.assertEqual(sess.rows[("gm_y", "u1")].items_extracted, 15)
+
+
+if __name__ == "__main__":
+    print("ak-bwe processedEmails upsert regression tests")
+    print("=" * 60)
+    unittest.main(verbosity=2, exit=False)
+    print("=" * 60)

--- a/utils/processed_emails_upsert.py
+++ b/utils/processed_emails_upsert.py
@@ -1,0 +1,220 @@
+"""ak-bwe: processedEmails upsert helper — idempotency for text-mode
+statement processing.
+
+BUG (dispatch hq-wisp-bk6efn, promoted to P1):
+
+  ak-5oi's backfill script (boi_backfill_2026.py and any similar
+  driver) invokes mailProcessorService.process_emails, which
+  processes PDF statements via _process_single_pdf_email →
+  _run_pdf_analysis → _run_all_chunks_async. Transactions land
+  correctly, PDFs get persisted, BUT no processedEmails row is
+  inserted for the ingested email.
+
+  _update_processed_email_pdf runs after persistence but is an
+  UPDATE-only path — it logs "No processedEmails row found for
+  {gmail_id} to update pdf_filename" and moves on. The row never
+  materializes.
+
+  On the next re-run (backfill re-fire, cron re-processing, ak-32o
+  HDFC re-parse), _filter_already_processed doesn't see the
+  gmail_id in processedEmails → the file gets re-ingested →
+  duplicate transactions accumulate (some absorbed by ak-8l5's
+  storage-layer dedup, some slipping past the ak-8l5-residual-B
+  edge case where suffixed rows land as -dupN vs -dup(N+1)).
+
+FIX:
+
+  Provide a single upsert function that either callers of
+  _handle_report_result (LLM tool path) OR the text-mode
+  processing path can use to stamp processedEmails after a
+  successful ingestion. Matches the shape of the existing
+  _handle_report_result upsert but decoupled from the tool-call
+  interface, so the service layer can call it directly with
+  strongly-typed args.
+
+  Pure-Python. Callers own the SQLAlchemy session; helper handles
+  the insert / integrity-error / update dance. Returns a dict with
+  the outcome so callers can log/return meaningful status.
+
+Related: ak-8l5 residual B (find_disambiguated_ref allocates a new
+-dupN on every re-parse instead of reusing when content matches a
+previously-suffixed row) is a separate downstream bug — this fix
+narrows the re-parse rate but doesn't fix the suffix-explosion
+edge case. That's tracked separately.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+
+# Tool-status → DB-status mapping (mirrors _handle_report_result so
+# behavior is identical whether the LLM path or the service-layer
+# path calls the upsert).
+_STATUS_MAP = {
+    "success": "processed",
+    "skipped": "skipped",
+    "error": "failed",
+}
+
+
+def _parse_email_date(raw_date) -> Optional[datetime]:
+    """Best-effort parse of a raw email_date string. Returns None if
+    none of the tolerated formats match (caller should degrade
+    gracefully — email_date is nullable in the schema)."""
+    if not raw_date:
+        return None
+    if isinstance(raw_date, datetime):
+        return raw_date
+    if not isinstance(raw_date, str):
+        return None
+    for fmt in (
+        "%Y-%m-%d",
+        "%d/%m/%Y",
+        "%d-%m-%Y",
+        "%Y-%m-%dT%H:%M:%S",
+    ):
+        try:
+            return datetime.strptime(raw_date, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def map_tool_status_to_db(tool_status: Optional[str]) -> str:
+    """Public tool-status → DB-status map. Unknown / missing → 'processed'
+    (matches pre-ak-bwe fallback in _handle_report_result)."""
+    if not tool_status:
+        return "processed"
+    return _STATUS_MAP.get(tool_status, "processed")
+
+
+def upsert_processed_email(
+    session,
+    processed_emails_model,
+    *,
+    gmail_id: str,
+    user_id: str,
+    sender: Optional[str] = None,
+    subject: Optional[str] = None,
+    email_date=None,
+    category: Optional[str] = "unknown",
+    processing_type: Optional[str] = None,
+    status: Optional[str] = "success",
+    items_extracted: int = 0,
+    extraction_summary=None,
+    error_message: Optional[str] = None,
+    integrity_error_class=None,
+) -> dict:
+    """ak-bwe: upsert a processedEmails row.
+
+    - If no row exists for (gmail_id, user_id): INSERT.
+    - If a row exists (IntegrityError on the unique constraint):
+      UPDATE the mutable fields on the existing row.
+
+    Callers own the session — this helper commits after the write
+    and rolls back on failure. Returns:
+      {
+        "status": "inserted" | "updated" | "no_session" | "failed",
+        "gmail_id": <id>,
+        "db_status": <mapped from `status`>,
+      }
+
+    integrity_error_class defaults to sqlalchemy.exc.IntegrityError;
+    injected for tests so they can raise a stand-in without pulling
+    SQLAlchemy in.
+
+    Contract:
+      - Never raises. Always returns a dict with a "status" field.
+      - When the row already exists and the incoming status is
+        'processed' (or maps to it), the previous row's status is
+        overwritten. That's intentional — a successful re-parse
+        should upgrade a prior 'failed'/'skipped' row to 'processed'.
+    """
+    if not gmail_id or not user_id:
+        return {"status": "failed", "gmail_id": gmail_id, "reason": "missing key"}
+
+    if session is None:
+        return {"status": "no_session", "gmail_id": gmail_id}
+
+    if integrity_error_class is None:
+        try:
+            from sqlalchemy.exc import IntegrityError as _IE
+            integrity_error_class = _IE
+        except Exception:  # pragma: no cover — defensive
+            integrity_error_class = Exception
+
+    db_status = map_tool_status_to_db(status)
+    parsed_email_date = _parse_email_date(email_date)
+
+    try:
+        row = processed_emails_model(
+            gmail_id=gmail_id,
+            user_id=user_id,
+            sender=sender,
+            subject=subject,
+            email_date=parsed_email_date,
+            category=category,
+            processing_type=processing_type,
+            status=db_status,
+            items_extracted=items_extracted or 0,
+            extraction_summary=extraction_summary,
+            error_message=error_message if db_status == "failed" else None,
+        )
+        session.add(row)
+        session.commit()
+        return {
+            "status": "inserted",
+            "gmail_id": gmail_id,
+            "db_status": db_status,
+        }
+    except integrity_error_class:
+        session.rollback()
+        try:
+            existing = session.query(processed_emails_model).filter_by(
+                gmail_id=gmail_id, user_id=user_id,
+            ).first()
+            if existing is None:
+                # Rare race — the row disappeared between the
+                # IntegrityError and the query. Log and give up
+                # (idempotency isn't threatened; something else
+                # will re-stamp on next run).
+                return {
+                    "status": "failed",
+                    "gmail_id": gmail_id,
+                    "reason": "row vanished after IntegrityError",
+                }
+            existing.category = category
+            existing.status = db_status
+            existing.items_extracted = items_extracted or 0
+            existing.extraction_summary = extraction_summary
+            existing.processing_type = processing_type
+            if db_status == "failed":
+                existing.error_message = error_message
+            session.commit()
+            return {
+                "status": "updated",
+                "gmail_id": gmail_id,
+                "db_status": db_status,
+            }
+        except Exception as e:
+            try:
+                session.rollback()
+            except Exception:
+                pass
+            return {
+                "status": "failed",
+                "gmail_id": gmail_id,
+                "reason": f"update failed: {e}",
+            }
+    except Exception as e:
+        try:
+            session.rollback()
+        except Exception:
+            pass
+        return {
+            "status": "failed",
+            "gmail_id": gmail_id,
+            "reason": f"insert failed: {e}",
+        }

--- a/utils/processed_emails_upsert.py
+++ b/utils/processed_emails_upsert.py
@@ -82,6 +82,35 @@ def _parse_email_date(raw_date) -> Optional[datetime]:
     return None
 
 
+def should_stamp_success(analysis_summary) -> bool:
+    """ak-bwe v2: decide whether _process_single_pdf_email should
+    stamp processedEmails with status='success' after a call to
+    _run_pdf_analysis.
+
+    Contract:
+      - True iff `analysis_summary` is a dict with `success` truthy
+        AND `failed_chunks` empty (or absent).
+      - False on None, non-dict, missing 'success', explicit
+        success=False, OR non-empty failed_chunks even when success
+        is truthy (defensive — the two should agree, but if they
+        disagree we treat any failure signal as authoritative).
+
+    The zero-loss preference: prefer to NOT stamp (re-run retries
+    the file) over stamping something that might silently lose
+    transactions. False is the safe default.
+    """
+    if not isinstance(analysis_summary, dict):
+        return False
+    if not analysis_summary.get("success"):
+        return False
+    if analysis_summary.get("failed_chunks"):
+        # success=True with non-empty failed_chunks is a
+        # contradiction the caller can't safely act on — treat
+        # as failure.
+        return False
+    return True
+
+
 def map_tool_status_to_db(tool_status: Optional[str]) -> str:
     """Public tool-status → DB-status map. Unknown / missing → 'processed'
     (matches pre-ak-bwe fallback in _handle_report_result)."""


### PR DESCRIPTION
processedEmails stamp for backfill idempotency: v1 stamp on text-mode ingest, v2 gate on genuine ingest success (zero-loss), v3 single-chunk unknown-result default fail-CLOSED. No schema/ALTER (existing table), no deploy prereq, 0 destructive. Rebased on 1563dd9. co:false.